### PR TITLE
fix support database selection with sentinel

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -618,9 +618,10 @@ class WP_Object_Cache {
             $parameters['read_write_timeout'] = $parameters['read_timeout'];
         }
 
-        if ( isset( $parameters['password'] ) ) {
-            foreach ( array( 'WP_REDIS_SERVERS', 'WP_REDIS_SHARDS', 'WP_REDIS_CLUSTER' ) as $constant ) {
-                if ( defined( $constant ) ) {
+        foreach (array('WP_REDIS_SERVERS', 'WP_REDIS_SHARDS', 'WP_REDIS_CLUSTER') as $constant) {
+            if ( defined ( $constant ) ) {
+                $options['parameters']['database'] = $parameters['database'];
+                if ( isset( $parameters['password'] ) ) {
                     $options['parameters']['password'] = WP_REDIS_PASSWORD;
                 }
             }


### PR DESCRIPTION
HI @tillkruss,
we use Redis with sentinel on our infrastructure and I notice that the DB selected is already the 0 even if we have set the WP_REDIS_DATABASE with a different value.

I see that predis library support the database choice https://github.com/nrk/predis/issues/291# and I added the $options['parameters']['database'] = $parameters['database']; in the same way of WP_REDIS_PASSWORD and it works.

Thanks in advance.
Fabio