### PR TITLE
Connection error using predis with sentinel configuration

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -401,7 +401,10 @@ class WP_Object_Cache {
                 $this->redis->ping();
             }
 
-            $options = method_exists( $this->redis, 'getOptions' ) ? $this->redis->getOptions() : new stdClass();
+            $options = method_exists( $this->redis, 'getOptions' )
+                ? $this->redis->getOptions()
+                : new stdClass();
+
             if ( ! isset( $options->replication ) || ! $options->replication ) {
                 if ( defined( 'WP_REDIS_CLUSTER' ) ) {
                     $info = $this->redis->info( current( array_values( WP_REDIS_CLUSTER ) ) );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -401,7 +401,8 @@ class WP_Object_Cache {
                 $this->redis->ping();
             }
 
-            if ( ! isset( $options['replication'] ) || ! $options['replication'] ) {
+            $options = method_exists( $this->redis, 'getOptions' ) ? $this->redis->getOptions() : new stdClass();
+            if ( ! isset( $options->replication ) || ! $options->replication ) {
                 if ( defined( 'WP_REDIS_CLUSTER' ) ) {
                     $info = $this->redis->info( current( array_values( WP_REDIS_CLUSTER ) ) );
                 } else {


### PR DESCRIPTION
As there are separate connection methods now the options variable in the constructor it not set failing the test for the correct `info` command.

There might be a better approach to this populating the `info` property in the specific connection methods instead.