### PR TITLE
Fixed `require_once` error updating from version 2.0.0

### DIFF
--- a/dependencies/vendor/predis/predis/autoload.php
+++ b/dependencies/vendor/predis/predis/autoload.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Compatiblity file to avoid WSOD/recovery-mode updating from 2.0.0 as
+ * `require_once` was defined by a condition in this specific version.
+ *
+ * Simply returning false will promt the admin to update his `object-cache.php`
+ */
+
+return false;

--- a/dependencies/vendor/predis/predis/autoload.php
+++ b/dependencies/vendor/predis/predis/autoload.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * Compatiblity file to avoid WSOD/recovery-mode updating from 2.0.0 as
- * `require_once` was defined by a condition in this specific version.
+ * Compatiblity file to avoid WSOD/recovery-mode when updating from 2.0.0 to 2.0.1.
  *
- * Simply returning false will promt the admin to update his `object-cache.php`
+ * Returning `false` will force the plugin to update the `object-cache.php` dropin.
  */
 
 return false;

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -613,7 +613,10 @@ class WP_Object_Cache {
                 defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins'
             );
 
-            if ( ! require_once $predis ) {
+
+            if ( is_readable( $predis ) ) {
+                require_once $predis;
+            } else {
                 throw new Exception(
                     'Predis library not found. Re-install Redis Cache plugin or delete the object-cache.php.'
                 );


### PR DESCRIPTION
In 2.0.0 we introduced the following line relying on the return value of `require_once` to throw an exception: https://github.com/rhubarbgroup/redis-cache/blob/6036289b6273465347fd4a307e0dfb5f6940619c/includes/object-cache.php#L616

Not only can this construct not be used to determine if a file was loaded correctly as the file itself can return any value at any time but the evaluation of the return value happens after the loading process itself. If this loading process generates an error it will do so before the return value can be read.

To be backwards compatible I reintroduced the `dependencies/vendor/predis/predis/autoload.php` file and just let it return `false` in order for the connection method to throw and prompt the admin to update `object-cache.php`.

As a side note interpreting the `require_once` return value is tricky as it will return `true` if  the file was required before (same goes for `include_once` - [php.net docs](https://www.php.net/manual/en/function.include-once.php))