### PR TITLE
Fix support for custom ports with credis

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -761,7 +761,7 @@ class WP_Object_Cache {
                 : $parameters['host'];
 
             $args = [
-                "{$parameters['scheme']}://{$host}",
+                "{$parameters['scheme']}://{$host}:{$parameters['port']}",
                 $parameters['port'],
                 $parameters['timeout'],
                 '',


### PR DESCRIPTION
I changed to credis today, and it turns out the connection string needs to also provide the port here. 