### PR TITLE
JS respect disable banners + simplification

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -361,7 +361,7 @@
                     continue;
                 }
                 rediscache.charts[type].series.push({
-                    name: 'Pro',
+                    name: rediscache.l10n.pro,
                     type: 'line',
                     data: metrics[type].map( pro_charts[type] ),
                 });

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -357,29 +357,13 @@
             name: 'Time',
             type: 'area',
             data: time,
-        }, {
-            name: 'Pro',
-            type: 'line',
-            data: time.map(
-                function ( entry ) {
-                    return [ entry[0], entry[1] * 0.5 ];
-                }
-            ),
-        } ];
+        }];
 
         rediscache.charts.bytes.series = [{
             name: rediscache.l10n.bytes,
             type: 'area',
             data: bytes,
-        }, {
-            name: 'Pro',
-            type: 'line',
-            data: bytes.map(
-                function ( entry ) {
-                    return [ entry[0], entry[1] * 0.3 ];
-                }
-            ),
-        } ];
+        }];
 
         rediscache.charts.ratio.series = [{
             name: rediscache.l10n.ratio,
@@ -391,15 +375,41 @@
             name: rediscache.l10n.calls,
             type: 'area',
             data: calls,
-        }, {
-            name: 'Pro',
-            type: 'line',
-            data: calls.map(
-                function ( entry ) {
-                    return [ entry[0], Math.round( entry[1] / 50 ) + 5 ];
-                }
-            ),
-        } ];
+        }];
+
+        if ( rediscache.on_settings_page || ! rediscache.disable_banners ) {
+
+            rediscache.charts.time.series.push({
+                name: 'Pro',
+                type: 'line',
+                data: time.map(
+                    function (entry) {
+                        return [entry[0], entry[1] * 0.5];
+                    }
+                ),
+            });
+
+            rediscache.charts.ratio.series.push({
+                name: 'Pro',
+                type: 'line',
+                data: bytes.map(
+                    function (entry) {
+                        return [entry[0], entry[1] * 0.3];
+                    }
+                ),
+            });
+
+            rediscache.charts.calls.series.push({
+                name: 'Pro',
+                type: 'line',
+                data: calls.map(
+                    function (entry) {
+                        return [entry[0], Math.round(entry[1] / 50) + 5];
+                    }
+                ),
+            });
+
+        }
     };
 
     // executed on page load

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -329,85 +329,43 @@
     };
 
     var setup_charts = function () {
-        var time = rediscache.metrics.computed.map(
-            function ( entry ) {
-                return [ entry.date, entry.time ];
+
+        var metrics = {};
+
+        for ( var type in rediscache.charts ) {
+            if ( ! rediscache.charts.hasOwnProperty( type ) ) {
+                continue;
             }
-        );
-
-        var bytes = rediscache.metrics.computed.map(
-            function ( entry ) {
-                return [ entry.date, entry.bytes ];
-            }
-        )
-
-        var ratio = rediscache.metrics.computed.map(
-            function ( entry ) {
-                return [ entry.date, entry.ratio ];
-            }
-        );
-
-        var calls = rediscache.metrics.computed.map(
-            function ( entry ) {
-                return [ entry.date, entry.calls ];
-            }
-        );
-
-        rediscache.charts.time.series = [{
-            name: 'Time',
-            type: 'area',
-            data: time,
-        }];
-
-        rediscache.charts.bytes.series = [{
-            name: rediscache.l10n.bytes,
-            type: 'area',
-            data: bytes,
-        }];
-
-        rediscache.charts.ratio.series = [{
-            name: rediscache.l10n.ratio,
-            type: 'area',
-            data: ratio,
-        }];
-
-        rediscache.charts.calls.series = [{
-            name: rediscache.l10n.calls,
-            type: 'area',
-            data: calls,
-        }];
+            metrics[type] = rediscache.metrics.computed.map(
+                function ( entry ) {
+                    return [ entry.date, entry[type] ];
+                }
+            );
+            rediscache.charts[type].series = [{
+                name: rediscache.l10n[type],
+                type: 'area',
+                data: metrics[type],
+            }];
+        }
 
         if ( rediscache.on_settings_page || ! rediscache.disable_banners ) {
 
-            rediscache.charts.time.series.push({
-                name: 'Pro',
-                type: 'line',
-                data: time.map(
-                    function (entry) {
-                        return [entry[0], entry[1] * 0.5];
-                    }
-                ),
-            });
+            var pro_charts = {
+                time: function( entry ) { return [ entry[0], entry[1] * 0.5 ] },
+                ratio: function( entry ) { return [ entry[0], entry[1] * 0.3 ] },
+                calls: function( entry ) { return [ entry[0], Math.round(entry[1] / 50) + 5 ] },
+            };
 
-            rediscache.charts.ratio.series.push({
-                name: 'Pro',
-                type: 'line',
-                data: bytes.map(
-                    function (entry) {
-                        return [entry[0], entry[1] * 0.3];
-                    }
-                ),
-            });
-
-            rediscache.charts.calls.series.push({
-                name: 'Pro',
-                type: 'line',
-                data: calls.map(
-                    function (entry) {
-                        return [entry[0], Math.round(entry[1] / 50) + 5];
-                    }
-                ),
-            });
+            for ( var type in pro_charts ) {
+                if ( ! rediscache.charts[type] ) {
+                    continue;
+                }
+                rediscache.charts[type].series.push({
+                    name: 'Pro',
+                    type: 'line',
+                    data: metrics[type].map( pro_charts[type] ),
+                });
+            }
 
         }
     };

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -218,6 +218,8 @@ class Plugin {
             'rediscache',
             array(
                 'jQuery' => 'jQuery',
+                'on_settings_page' => $screen->id === $this->screen,
+                'disable_banners' => defined( 'WP_REDIS_DISABLE_BANNERS' ) && WP_REDIS_DISABLE_BANNERS,
                 'l10n' => array(
                     'time' => __( 'Time', 'redis-cache' ),
                     'bytes' => __( 'Bytes', 'redis-cache' ),


### PR DESCRIPTION
The dashboard widget now respects the `WP_REDIS_DISABLE_BANNERS` constant.

Also seized a chance to simplify the graph generation code fixing some inconsistencies in the process.