### PR TITLE
Docker improvements

### DIFF
--- a/docker/apf-template.php
+++ b/docker/apf-template.php
@@ -1,6 +1,7 @@
 <?php
 
 $constants = [
+    'WP_ENVIRONMENT_TYPE' => 'development',
     'WP_DEBUG' => true,
     'SCRIPT_DEBUG' => true,
     'CONCATENATE_SCRIPTS' => false,

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -118,14 +118,12 @@ for i in "$@"; do
   index=index+1;
 done;
 
-: ${client-phpredis}
-
 case ${options[0]} in
 
     ""|"-"|"simple"|"default"|"up"|"start")
         start 1 0 0 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-phpredis}"
         apf WP_REDIS_HOST redis-master
         restart_apache
         ;;
@@ -133,7 +131,7 @@ case ${options[0]} in
     "replication"|"repl")
         start 1 3 0 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-phpredis}"
         apf WP_REDIS_SERVERS \
             tcp://$(dcip redis-master):6379?alias=master \
             tcp://$(dcip redis-slave 1):6379?alias=slave-01 \
@@ -145,7 +143,7 @@ case ${options[0]} in
     "sentinel"|"sent")
         start 1 5 3 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-predis}"
         apf WP_REDIS_SENTINEL master
         apf WP_REDIS_SERVERS \
             tcp://$(dcip redis-sentinel 1):26379 \
@@ -157,7 +155,7 @@ case ${options[0]} in
     "shard"|"sharding")
         start 3 0 0 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-predis}"
         apf WP_REDIS_SHARDS \
             tcp://$(dcip redis-master 1):6379?alias=shard-01 \
             tcp://$(dcip redis-master 2):6379?alias=shard-02 \
@@ -167,7 +165,7 @@ case ${options[0]} in
 
     "cluster"|"clustering")
         start 3 0 0 ${options[@]:1}
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-predis}"
         apf WP_REDIS_CLUSTER \
             tcp://$(dcip redis-master 1):6379?alias=node-01 \
             tcp://$(dcip redis-master 2):6379?alias=node-02 \
@@ -178,7 +176,7 @@ case ${options[0]} in
     "stop"|"down")
         stop ${options[@]:0}
         apf --reset
-        apf WP_REDIS_CLIENT "$client"
+        apf WP_REDIS_CLIENT "${client-phpredis}"
         apf WP_REDIS_HOST redis-master
         ;;
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -79,19 +79,61 @@ function restart_apache {
     compose exec wordpress apachectl restart
 }
 
-case $1 in
+# Get command arguments
+# Reference https://stackoverflow.com/questions/7069682/how-to-get-arguments-with-flags-in-bash
+declare -A arguments=();
+declare -A variables=();
+declare options=();
+declare -i index=1;
+
+variables["-c"]="client";
+variables["--client"]="client";
+
+for i in "$@"; do
+  arguments[$index]=$i;
+  prev_index="$(expr $index - 1)";
+
+  # this if block does something akin to "where $i contains ="
+  # "%=*" here strips out everything from the = to the end of the argument leaving only the label
+  if [[ $i == *"="* ]]
+    then argument_label=${i%=*}
+    else argument_label=${arguments[$prev_index]}
+  fi
+
+  if [[ -n $argument_label ]] ; then
+    # this if block only evaluates to true if the argument label exists in the variables array
+    if [[ -n ${variables[$argument_label]} ]] ; then
+      # dynamically creating variables names using declare
+      # "#$argument_label=" here strips out the label leaving only the value
+      if [[ $i == *"="* ]]
+        then declare ${variables[$argument_label]}=${i#$argument_label=} 
+        else declare ${variables[$argument_label]}=${arguments[$index]}
+      fi
+    else
+      # if the argument was not found store it in order
+      options+=(${arguments[$index]})
+    fi
+  fi
+
+  index=index+1;
+done;
+
+: ${client-phpredis}
+
+case ${options[0]} in
 
     ""|"-"|"simple"|"default"|"up"|"start")
-        start 1 0 0 ${@:2}
+        start 1 0 0 ${options[@]:1}
         apf --reset
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_HOST redis-master
         restart_apache
         ;;
 
     "replication"|"repl")
-        start 1 3 0 ${@:2}
+        start 1 3 0 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT predis
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_SERVERS \
             tcp://$(dcip redis-master):6379?alias=master \
             tcp://$(dcip redis-slave 1):6379?alias=slave-01 \
@@ -101,9 +143,9 @@ case $1 in
         ;;
 
     "sentinel"|"sent")
-        start 1 5 3 ${@:2}
+        start 1 5 3 ${options[@]:1}
         apf --reset
-        apf WP_REDIS_CLIENT predis
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_SENTINEL master
         apf WP_REDIS_SERVERS \
             tcp://$(dcip redis-sentinel 1):26379 \
@@ -113,8 +155,9 @@ case $1 in
         ;;
 
     "shard"|"sharding")
-        start 3 0 0 ${@:2}
+        start 3 0 0 ${options[@]:1}
         apf --reset
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_SHARDS \
             tcp://$(dcip redis-master 1):6379?alias=shard-01 \
             tcp://$(dcip redis-master 2):6379?alias=shard-02 \
@@ -123,7 +166,8 @@ case $1 in
         ;;
 
     "cluster"|"clustering")
-        start 3 0 0 ${@:2}
+        start 3 0 0 ${options[@]:1}
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_CLUSTER \
             tcp://$(dcip redis-master 1):6379?alias=node-01 \
             tcp://$(dcip redis-master 2):6379?alias=node-02 \
@@ -132,12 +176,13 @@ case $1 in
         ;;
 
     "stop"|"down")
-        stop ${@:1}
+        stop ${options[@]:0}
         apf --reset
+        apf WP_REDIS_CLIENT "$client"
         apf WP_REDIS_HOST redis-master
         ;;
 
-    *) echo "unrecognized command $1"
+    *) echo "unrecognized command ${options[@]:1}"
         exit
         ;;
 


### PR DESCRIPTION
You can now easily define the client to be used using the `-c` or the `--client` flag.
Example: `docker/start.sh -c credis replication`

Will update the wiki once this is merged.