### PR TITLE
Cron missed logic

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -834,6 +834,10 @@ class Plugin {
             return;
         }
 
+        if ( $this->has_missed_cron() ) {
+            return;
+        }
+
         $info = $wp_object_cache->info();
 
         $metrics = [
@@ -886,6 +890,26 @@ class Plugin {
         } catch ( Exception $exception ) {
             error_log( $exception ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
         }
+    }
+
+    /**
+     * Checks if a cron is overdue and was most likely missed
+     *
+     * @return bool
+     */
+    private function has_missed_cron() {
+        static $has_missed_cron;
+        if ( ! isset( $has_missed_cron ) ) {
+            $variance   = 15 * MINUTE_IN_SECONDS;
+            $cron_tasks = wp_get_ready_cron_jobs();
+            if ( ! $cron_tasks ) {
+                $has_missed_cron = false;
+            } else {
+                $cron_times      = array_keys( $cron_tasks );
+                $has_missed_cron = ( $cron_times[0] - time() ) < - $variance;
+            }
+        }
+        return $has_missed_cron;
     }
 
     /**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -557,6 +557,10 @@ class Plugin {
             $this->wc_pro_notice();
         }
 
+        if ( ( ! defined( 'WP_REDIS_DISABLE_METRICS' ) || ! WP_REDIS_DISABLE_METRICS ) && $this->has_missed_cron() ) {
+            $this->cron_issue_notice();
+        }
+
         // Only show admin notices to users with the right capability.
         if ( ! current_user_can( is_multisite() ? 'manage_network_options' : 'manage_options' ) ) {
             return;
@@ -801,6 +805,31 @@ class Plugin {
                 esc_url( network_admin_url( $this->page ) )
             )
         );
+    }
+
+    /**
+     * Displays a notice if we detected issues with the cron system
+     *
+     * @return void
+     */
+    public function cron_issue_notice() {
+        $screen = get_current_screen();
+
+        if ( ! isset( $screen->id ) ) {
+            return;
+        }
+
+        if ( ! in_array( $screen->id, array( $this->screen ), true ) ) {
+            return;
+        }
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $message = __( 'Redis Object Cache has detected issues with your cron subsystem. Collecting metrics was disabled because of this.', 'redis-cache' );
+
+        printf( '<div class="update-nag">%s</div>', wp_kses_post( $message ) );
     }
 
     /**


### PR DESCRIPTION
Adds logic to detect cron events failing to execute (event did not run within 15 minutes) and adds an admin notice if this is the case.

The notice might need a link to some troubleshooting article.