### PR TITLE
"Statification" of the plugin class

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -438,7 +438,7 @@ class Plugin {
      *
      * @return string
      */
-    public function get_status() {
+    public static function get_status() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1024,7 +1024,7 @@ class Plugin {
      *
      * @return true|WP_Error
      */
-    public function test_filesystem_writing() {
+    public static function test_filesystem_writing() {
         global $wp_filesystem;
 
         if ( ! self::initialize_filesystem( '', true ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -116,7 +116,7 @@ class Plugin {
         add_action( 'rediscache_discard_metrics', [ $this, 'discard_metrics' ] );
 
         add_filter( 'qm/collectors', [ self::class, 'register_qm_collector' ], 25 );
-        add_filter( 'qm/outputter/html', array( $this, 'register_qm_output' ) );
+        add_filter( 'qm/outputter/html', [ self::class, 'register_qm_output' ] );
     }
 
     /**
@@ -383,7 +383,7 @@ class Plugin {
      * @param array $output Array of current QM_Output handlers.
      * @return array
      */
-    public function register_qm_output( $output ) {
+    public static function register_qm_output( $output ) {
         $collector = \QM_Collectors::get( 'cache' );
 
         if (

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -86,8 +86,8 @@ class Plugin {
 
         add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'add_admin_menu_page' ] );
 
-        add_action( 'admin_notices', [ $this, 'show_admin_notices' ] );
-        add_action( 'network_admin_notices', [ $this, 'show_admin_notices' ] );
+        add_action( 'admin_notices', [ self::class, 'show_admin_notices' ] );
+        add_action( 'network_admin_notices', [ self::class, 'show_admin_notices' ] );
 
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_styles' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
@@ -556,7 +556,7 @@ class Plugin {
      *
      * @return void
      */
-    public function show_admin_notices() {
+    public static function show_admin_notices() {
         if ( ! defined( 'WP_REDIS_DISABLE_BANNERS' ) || ! WP_REDIS_DISABLE_BANNERS ) {
             self::pro_notice();
             self::wc_pro_notice();

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -61,9 +61,9 @@ class Plugin {
      *
      * @return void
      */
-    public function add_actions_and_filters() {
+    public static function add_actions_and_filters() {
         add_action( 'deactivate_plugin', [ self::class, 'on_deactivation' ] );
-        add_action( 'admin_init',[ self::class, 'maybe_update_dropin' ] );
+        add_action( 'admin_init', [ self::class, 'maybe_update_dropin' ] );
         add_action( 'init', [ $this, 'init' ] );
 
         add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ self::class, 'add_admin_menu_page' ] );

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -36,7 +36,7 @@ class Plugin {
      *
      * @var string[] $actions
      */
-    private $actions = [
+    private static $actions = [
         'enable-cache',
         'disable-cache',
         'flush-cache',
@@ -159,7 +159,7 @@ class Plugin {
             $action = sanitize_key( $_GET['action'] );
             $nonce = sanitize_key( $_GET['_wpnonce'] );
 
-            foreach ( $this->actions as $name ) {
+            foreach ( self::$actions as $name ) {
                 // Nonce verification.
                 if ( $action === $name && wp_verify_nonce( $nonce, $action ) ) {
                     $url = $this->action_link( $action );
@@ -607,13 +607,13 @@ class Plugin {
             $nonce = sanitize_key( $_GET['_wpnonce'] );
 
             // Nonce verification.
-            foreach ( $this->actions as $name ) {
+            foreach ( self::$actions as $name ) {
                 if ( $action === $name && ! wp_verify_nonce( $nonce, $action ) ) {
                     return;
                 }
             }
 
-            if ( in_array( $action, $this->actions, true ) ) {
+            if ( in_array( $action, self::$actions, true ) ) {
                 $url = $this->action_link( $action );
 
                 if ( $action === 'flush-cache' ) {
@@ -1154,7 +1154,7 @@ class Plugin {
      * @return string
      */
     public function action_link( $action ) {
-        if ( ! in_array( $action, $this->actions, true ) ) {
+        if ( ! in_array( $action, self::$actions, true ) ) {
             return '';
         }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -101,7 +101,7 @@ class Plugin {
         add_action( 'wp_ajax_roc_dismiss_notice', [ self::class, 'dismiss_notice' ] );
 
         $links = sprintf( '%splugin_action_links_%s', is_multisite() ? 'network_admin_' : '', WP_REDIS_BASENAME );
-        add_filter( $links, [ $this, 'add_plugin_actions_links' ] );
+        add_filter( $links, [ self::class, 'add_plugin_actions_links' ] );
 
         add_action( 'wp_head', [ self::class, 'register_shutdown_hooks' ] );
         add_action( 'shutdown', array( $this, 'record_metrics' ) );
@@ -220,7 +220,7 @@ class Plugin {
      * @param string[] $links The current plugin action links.
      * @return string[]
      */
-    public function add_plugin_actions_links( $links ) {
+    public static function add_plugin_actions_links( $links ) {
         return array_merge(
             [ sprintf( '<a href="%s">%s</a>', network_admin_url( self::page() ), esc_html__( 'Settings', 'redis-cache' ) ) ],
             $links

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -44,29 +44,11 @@ class Plugin {
     ];
 
     /**
-     * Plugin instance property
+     * Initialization method
      *
-     * @var Plugin
+     * @return void
      */
-    private static $instance;
-
-    /**
-     * Plugin instanciation method
-     *
-     * @return Plugin
-     */
-    public static function instance() {
-        if ( ! isset( self::$instance ) ) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
-    }
-
-    /**
-     * Constructor
-     */
-    private function __construct() {
+    public static function init() {
         require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
         register_activation_hook( WP_REDIS_FILE, 'wp_cache_flush' );

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1085,7 +1085,7 @@ class Plugin {
         }
 
         if ( $this->object_cache_dropin_outdated() ) {
-            add_action( 'shutdown', [ $this, 'update_dropin' ] );
+            add_action( 'shutdown', [ self::class, 'update_dropin' ] );
         }
     }
 
@@ -1094,7 +1094,7 @@ class Plugin {
      *
      * @return void
      */
-    public function update_dropin() {
+    public static function update_dropin() {
         global $wp_filesystem;
 
         if ( ! self::validate_object_cache_dropin() ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -558,7 +558,7 @@ class Plugin {
      */
     public function show_admin_notices() {
         if ( ! defined( 'WP_REDIS_DISABLE_BANNERS' ) || ! WP_REDIS_DISABLE_BANNERS ) {
-            $this->pro_notice();
+            self::pro_notice();
             self::wc_pro_notice();
         }
 
@@ -754,7 +754,7 @@ class Plugin {
      *
      * @return void
      */
-    public function pro_notice() {
+    public static function pro_notice() {
         $screen = get_current_screen();
 
         if ( ! isset( $screen->id ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -89,7 +89,7 @@ class Plugin {
      */
     public function add_actions_and_filters() {
         add_action( 'deactivate_plugin', [ $this, 'on_deactivation' ] );
-        add_action( 'admin_init', [ $this, 'maybe_update_dropin' ] );
+        add_action( 'admin_init',[ self::class, 'maybe_update_dropin' ] );
         add_action( 'init', [ $this, 'init' ] );
 
         add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'add_admin_menu_page' ] );
@@ -1079,7 +1079,7 @@ class Plugin {
      *
      * @return void
      */
-    public function maybe_update_dropin() {
+    public static function maybe_update_dropin() {
         if ( defined( 'WP_REDIS_DISABLE_DROPIN_AUTOUPDATE' ) && WP_REDIS_DISABLE_DROPIN_AUTOUPDATE ) {
             return;
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -84,7 +84,7 @@ class Plugin {
         add_action( 'admin_init',[ self::class, 'maybe_update_dropin' ] );
         add_action( 'init', [ $this, 'init' ] );
 
-        add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ $this, 'add_admin_menu_page' ] );
+        add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ self::class, 'add_admin_menu_page' ] );
 
         add_action( 'admin_notices', [ self::class, 'show_admin_notices' ] );
         add_action( 'network_admin_notices', [ self::class, 'show_admin_notices' ] );
@@ -129,7 +129,7 @@ class Plugin {
      *
      * @return void
      */
-    public function add_admin_menu_page() {
+    public static function add_admin_menu_page() {
         add_submenu_page(
             is_multisite() ? 'settings.php' : 'options-general.php',
             __( 'Redis Object Cache', 'redis-cache' ),

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -201,7 +201,7 @@ class Plugin {
         wp_add_dashboard_widget(
             'dashboard_rediscache',
             __( 'Redis Object Cache', 'redis-cache' ),
-            [ $this, 'show_dashboard_widget' ]
+            [ self::class, 'show_dashboard_widget' ]
         );
     }
 
@@ -210,7 +210,7 @@ class Plugin {
      *
      * @return void
      */
-    public function show_dashboard_widget() {
+    public static function show_dashboard_widget() {
         require_once WP_REDIS_PLUGIN_PATH . '/includes/ui/widget.php';
     }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -538,7 +538,7 @@ class Plugin {
      *
      * @return null|mixed
      */
-    public function get_redis_prefix() {
+    public static function get_redis_prefix() {
         return defined( 'WP_REDIS_PREFIX' ) ? WP_REDIS_PREFIX : null;
     }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -154,7 +154,7 @@ class Plugin {
             foreach ( self::$actions as $name ) {
                 // Nonce verification.
                 if ( $action === $name && wp_verify_nonce( $nonce, $action ) ) {
-                    $url = $this->action_link( $action );
+                    $url = self::action_link( $action );
 
                     if ( self::initialize_filesystem( $url ) === false ) {
                         return; // Request filesystem credentials.
@@ -568,7 +568,7 @@ class Plugin {
         }
 
         if ( self::object_cache_dropin_exists() ) {
-            $url = $this->action_link( 'update-dropin' );
+            $url = self::action_link( 'update-dropin' );
 
             if ( self::validate_object_cache_dropin() ) {
                 if ( self::object_cache_dropin_outdated() ) {
@@ -606,7 +606,6 @@ class Plugin {
             }
 
             if ( in_array( $action, self::$actions, true ) ) {
-                $url = $this->action_link( $action );
 
                 if ( $action === 'flush-cache' ) {
                     wp_cache_flush()
@@ -625,7 +624,7 @@ class Plugin {
                 }
 
                 // do we have filesystem credentials?
-                if ( self::initialize_filesystem( $url, true ) ) {
+                if ( self::initialize_filesystem( self::action_link( $action ), true ) ) {
 
                     if ( $action === 'enable-cache' ) {
                         $result = $wp_filesystem->copy(
@@ -1145,7 +1144,7 @@ class Plugin {
      * @param string $action The action to be executed once the link is followed.
      * @return string
      */
-    public function action_link( $action ) {
+    public static function action_link( $action ) {
         if ( ! in_array( $action, self::$actions, true ) ) {
             return '';
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -93,7 +93,7 @@ class Plugin {
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
         add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_redis_metrics' ] );
 
-        add_action( 'load-settings_page_redis-cache', [ $this, 'do_admin_actions' ] );
+        add_action( 'load-settings_page_redis-cache', [ self::class, 'do_admin_actions' ] );
 
         add_action( 'wp_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
         add_action( 'wp_network_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
@@ -591,7 +591,7 @@ class Plugin {
      *
      * @return void
      */
-    public function do_admin_actions() {
+    public static function do_admin_actions() {
         global $wp_filesystem;
 
         if ( isset( $_GET['_wpnonce'], $_GET['action'] ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -257,7 +257,7 @@ class Plugin {
      *
      * @return void
      */
-    public function enqueue_admin_scripts() {
+    public static function enqueue_admin_scripts() {
         $screen = get_current_screen();
 
         if ( ! isset( $screen->id ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -136,7 +136,7 @@ class Plugin {
             __( 'Redis', 'redis-cache' ),
             is_multisite() ? 'manage_network_options' : 'manage_options',
             'redis-cache',
-            [ $this, 'show_admin_page' ]
+            [ self::class, 'show_admin_page' ]
         );
     }
 
@@ -145,7 +145,7 @@ class Plugin {
      *
      * @return void
      */
-    public function show_admin_page() {
+    public static function show_admin_page() {
         // Request filesystem credentials?
         if ( isset( $_GET['_wpnonce'], $_GET['action'] ) ) {
             $action = sanitize_key( $_GET['action'] );

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -89,9 +89,9 @@ class Plugin {
         add_action( 'admin_notices', [ self::class, 'show_admin_notices' ] );
         add_action( 'network_admin_notices', [ self::class, 'show_admin_notices' ] );
 
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_styles' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_admin_scripts' ] );
-        add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_redis_metrics' ] );
+        add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_admin_styles' ] );
+        add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_admin_scripts' ] );
+        add_action( 'admin_enqueue_scripts', [ self::class, 'enqueue_redis_metrics' ] );
 
         add_action( 'load-settings_page_redis-cache', [ self::class, 'do_admin_actions' ] );
 
@@ -232,7 +232,7 @@ class Plugin {
      *
      * @return void
      */
-    public function enqueue_admin_styles() {
+    public static function enqueue_admin_styles() {
         $screen = get_current_screen();
 
         if ( ! isset( $screen->id ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -426,7 +426,7 @@ class Plugin {
      *
      * @return bool
      */
-    public function object_cache_dropin_outdated() {
+    public static function object_cache_dropin_outdated() {
         if ( ! self::object_cache_dropin_exists() ) {
             return false;
         }
@@ -579,7 +579,7 @@ class Plugin {
             $url = $this->action_link( 'update-dropin' );
 
             if ( self::validate_object_cache_dropin() ) {
-                if ( $this->object_cache_dropin_outdated() ) {
+                if ( self::object_cache_dropin_outdated() ) {
                     // translators: %s = Action link to update the drop-in.
                     $message = sprintf( __( 'The Redis object cache drop-in is outdated. Please <a href="%s">update the drop-in</a>.', 'redis-cache' ), $url );
                 }
@@ -1084,7 +1084,7 @@ class Plugin {
             return;
         }
 
-        if ( $this->object_cache_dropin_outdated() ) {
+        if ( self::object_cache_dropin_outdated() ) {
             add_action( 'shutdown', [ self::class, 'update_dropin' ] );
         }
     }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -401,7 +401,7 @@ class Plugin {
      *
      * @return bool
      */
-    public function object_cache_dropin_exists() {
+    public static function object_cache_dropin_exists() {
         return file_exists( WP_CONTENT_DIR . '/object-cache.php' );
     }
 
@@ -411,7 +411,7 @@ class Plugin {
      * @return bool
      */
     public function validate_object_cache_dropin() {
-        if ( ! $this->object_cache_dropin_exists() ) {
+        if ( ! self::object_cache_dropin_exists() ) {
             return false;
         }
 
@@ -427,7 +427,7 @@ class Plugin {
      * @return bool
      */
     public function object_cache_dropin_outdated() {
-        if ( ! $this->object_cache_dropin_exists() ) {
+        if ( ! self::object_cache_dropin_exists() ) {
             return false;
         }
 
@@ -453,7 +453,7 @@ class Plugin {
             return __( 'Disabled', 'redis-cache' );
         }
 
-        if ( ! $this->object_cache_dropin_exists() ) {
+        if ( ! self::object_cache_dropin_exists() ) {
             return __( 'Drop-in not installed', 'redis-cache' );
         }
 
@@ -575,7 +575,7 @@ class Plugin {
             return;
         }
 
-        if ( $this->object_cache_dropin_exists() ) {
+        if ( self::object_cache_dropin_exists() ) {
             $url = $this->action_link( 'update-dropin' );
 
             if ( $this->validate_object_cache_dropin() ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -832,7 +832,7 @@ class Plugin {
      */
     public function register_shutdown_hooks() {
         if ( ! defined( 'WP_REDIS_DISABLE_COMMENT' ) || ! WP_REDIS_DISABLE_COMMENT ) {
-            add_action( 'shutdown', [ $this, 'maybe_print_comment' ], 0 );
+            add_action( 'shutdown', [ self::class, 'maybe_print_comment' ], 0 );
         }
     }
 
@@ -915,7 +915,7 @@ class Plugin {
      *
      * @return void
      */
-    public function maybe_print_comment() {
+    public static function maybe_print_comment() {
         global $wp_object_cache;
 
         if (

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1142,7 +1142,7 @@ class Plugin {
      *
      * @return string
      */
-    private static function page() {
+    public static function page() {
         if ( ! self::$page ) {
             self::$page = is_multisite()
                 ? 'settings.php?page=redis-cache'
@@ -1156,7 +1156,7 @@ class Plugin {
      *
      * @return string
      */
-    private static function screen() {
+    public static function screen() {
         if ( ! self::$screen ) {
             self::$screen = is_multisite()
                 ? 'settings_page_redis-cache-network'

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -547,7 +547,7 @@ class Plugin {
      *
      * @return null|mixed
      */
-    public function get_redis_maxttl() {
+    public static function get_redis_maxttl() {
         return defined( 'WP_REDIS_MAXTTL' ) ? WP_REDIS_MAXTTL : null;
     }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -525,7 +525,7 @@ class Plugin {
      *
      * @return null|array
      */
-    public function get_diagnostics() {
+    public static function get_diagnostics() {
         global $wp_object_cache;
 
         if ( self::validate_object_cache_dropin() && property_exists( $wp_object_cache, 'diagnostics' ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -64,7 +64,7 @@ class Plugin {
     public static function add_actions_and_filters() {
         add_action( 'deactivate_plugin', [ self::class, 'on_deactivation' ] );
         add_action( 'admin_init', [ self::class, 'maybe_update_dropin' ] );
-        add_action( 'init', [ $this, 'init' ] );
+        add_action( 'init', [ self::class, 'wp_init' ] );
 
         add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', [ self::class, 'add_admin_menu_page' ] );
 
@@ -98,9 +98,9 @@ class Plugin {
      *
      * @return void
      */
-    public function init() {
+    public static function wp_init() {
         load_plugin_textdomain( 'redis-cache', false, 'redis-cache/languages' );
-        
+
         if ( is_admin() && ! wp_next_scheduled( 'rediscache_discard_metrics' ) ) {
             wp_schedule_event( time(), 'hourly', 'rediscache_discard_metrics' );
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -310,7 +310,7 @@ class Plugin {
      *
      * @return void
      */
-    public function enqueue_redis_metrics() {
+    public static function enqueue_redis_metrics() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLE_METRICS' ) && WP_REDIS_DISABLE_METRICS ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -80,7 +80,7 @@ class Plugin {
      * @return void
      */
     public function add_actions_and_filters() {
-        add_action( 'deactivate_plugin', [ $this, 'on_deactivation' ] );
+        add_action( 'deactivate_plugin', [ self::class, 'on_deactivation' ] );
         add_action( 'admin_init',[ self::class, 'maybe_update_dropin' ] );
         add_action( 'init', [ $this, 'init' ] );
 
@@ -1116,7 +1116,7 @@ class Plugin {
      * @param string $plugin Plugin basename.
      * @return void
      */
-    public function on_deactivation( $plugin ) {
+    public static function on_deactivation( $plugin ) {
         global $wp_filesystem;
 
         ob_start();

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -164,7 +164,7 @@ class Plugin {
                 if ( $action === $name && wp_verify_nonce( $nonce, $action ) ) {
                     $url = $this->action_link( $action );
 
-                    if ( $this->initialize_filesystem( $url ) === false ) {
+                    if ( self::initialize_filesystem( $url ) === false ) {
                         return; // Request filesystem credentials.
                     }
                 }
@@ -633,7 +633,7 @@ class Plugin {
                 }
 
                 // do we have filesystem credentials?
-                if ( $this->initialize_filesystem( $url, true ) ) {
+                if ( self::initialize_filesystem( $url, true ) ) {
 
                     if ( $action === 'enable-cache' ) {
                         $result = $wp_filesystem->copy(
@@ -1000,7 +1000,7 @@ class Plugin {
      * @param bool   $silent Wheather to ask the user for credentials if necessary or not.
      * @return bool
      */
-    public function initialize_filesystem( $url, $silent = false ) {
+    public static function initialize_filesystem( $url, $silent = false ) {
         if ( $silent ) {
             ob_start();
         }
@@ -1036,7 +1036,7 @@ class Plugin {
     public function test_filesystem_writing() {
         global $wp_filesystem;
 
-        if ( ! $this->initialize_filesystem( '', true ) ) {
+        if ( ! self::initialize_filesystem( '', true ) ) {
             return new WP_Error( 'fs', __( 'Could not initialize filesystem.', 'redis-cache' ) );
         }
 
@@ -1101,7 +1101,7 @@ class Plugin {
             return;
         }
 
-        if ( $this->initialize_filesystem( '', true ) ) {
+        if ( self::initialize_filesystem( '', true ) ) {
             $result = $wp_filesystem->copy(
                 WP_REDIS_PLUGIN_PATH . '/includes/object-cache.php',
                 WP_CONTENT_DIR . '/object-cache.php',
@@ -1139,7 +1139,7 @@ class Plugin {
 
             wp_cache_flush();
 
-            if ( $this->validate_object_cache_dropin() && $this->initialize_filesystem( '', true ) ) {
+            if ( $this->validate_object_cache_dropin() && self::initialize_filesystem( '', true ) ) {
                 $wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
             }
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -71,7 +71,7 @@ class Plugin {
 
         register_activation_hook( WP_REDIS_FILE, 'wp_cache_flush' );
 
-        $this->add_actions_and_filters();
+        self::add_actions_and_filters();
     }
 
     /**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -491,7 +491,7 @@ class Plugin {
      * @see WP_Object_Cache::redis_version()
      * @return null|string
      */
-    public function get_redis_version() {
+    public static function get_redis_version() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -103,9 +103,9 @@ class Plugin {
         $links = sprintf( '%splugin_action_links_%s', is_multisite() ? 'network_admin_' : '', WP_REDIS_BASENAME );
         add_filter( $links, [ $this, 'add_plugin_actions_links' ] );
 
-        add_action( 'wp_head', [ $this, 'register_shutdown_hooks' ] );
-        add_action( 'shutdown', [ $this, 'record_metrics' ] );
-        add_action( 'rediscache_discard_metrics', [ $this, 'discard_metrics' ] );
+        add_action( 'wp_head', [ self::class, 'register_shutdown_hooks' ] );
+        add_action( 'shutdown', array( $this, 'record_metrics' ) );
+        add_action( 'rediscache_discard_metrics', array( $this, 'discard_metrics' ) );
 
         add_filter( 'qm/collectors', [ self::class, 'register_qm_collector' ], 25 );
         add_filter( 'qm/outputter/html', [ self::class, 'register_qm_output' ] );
@@ -830,7 +830,7 @@ class Plugin {
      *
      * @return void
      */
-    public function register_shutdown_hooks() {
+    public static function register_shutdown_hooks() {
         if ( ! defined( 'WP_REDIS_DISABLE_COMMENT' ) || ! WP_REDIS_DISABLE_COMMENT ) {
             add_action( 'shutdown', [ self::class, 'maybe_print_comment' ], 0 );
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -95,8 +95,8 @@ class Plugin {
 
         add_action( 'load-settings_page_redis-cache', [ self::class, 'do_admin_actions' ] );
 
-        add_action( 'wp_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
-        add_action( 'wp_network_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
+        add_action( 'wp_dashboard_setup', [ self::class, 'setup_dashboard_widget' ] );
+        add_action( 'wp_network_dashboard_setup', [ self::class, 'setup_dashboard_widget' ] );
 
         add_action( 'wp_ajax_roc_dismiss_notice', [ self::class, 'dismiss_notice' ] );
 
@@ -193,7 +193,7 @@ class Plugin {
      *
      * @return void
      */
-    public function setup_dashboard_widget() {
+    public static function setup_dashboard_widget() {
         if ( defined( 'WP_REDIS_DISABLE_METRICS' ) && WP_REDIS_DISABLE_METRICS ) {
             return;
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -508,7 +508,7 @@ class Plugin {
      *
      * @return null|string
      */
-    public function get_redis_client_name() {
+    public static function get_redis_client_name() {
         global $wp_object_cache;
 
         if ( isset( $wp_object_cache->diagnostics[ 'client' ] ) ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -115,8 +115,8 @@ class Plugin {
         add_action( 'shutdown', [ $this, 'record_metrics' ] );
         add_action( 'rediscache_discard_metrics', [ $this, 'discard_metrics' ] );
 
-        add_filter( 'qm/collectors', [ $this, 'register_qm_collector' ], 25 );
-        add_filter( 'qm/outputter/html', [ $this, 'register_qm_output' ] );
+        add_filter( 'qm/collectors', [ self::class, 'register_qm_collector' ], 25 );
+        add_filter( 'qm/outputter/html', array( $this, 'register_qm_output' ) );
     }
 
     /**
@@ -371,7 +371,7 @@ class Plugin {
      * @param array $collectors Array of currently registered collectors.
      * @return array
      */
-    public function register_qm_collector( array $collectors ) {
+    public static function register_qm_collector( array $collectors ) {
         $collectors['cache'] = new QM_Collector();
 
         return $collectors;

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -98,7 +98,7 @@ class Plugin {
         add_action( 'wp_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
         add_action( 'wp_network_dashboard_setup', [ $this, 'setup_dashboard_widget' ] );
 
-        add_action( 'wp_ajax_roc_dismiss_notice', [ $this, 'dismiss_notice' ] );
+        add_action( 'wp_ajax_roc_dismiss_notice', [ self::class, 'dismiss_notice' ] );
 
         $links = sprintf( '%splugin_action_links_%s', is_multisite() ? 'network_admin_' : '', WP_REDIS_BASENAME );
         add_filter( $links, [ $this, 'add_plugin_actions_links' ] );
@@ -734,7 +734,7 @@ class Plugin {
      *
      * @return void
      */
-    public function dismiss_notice() {
+    public static function dismiss_notice() {
         if ( isset( $_POST['notice'] ) ) {
             check_ajax_referer( 'roc_dismiss_notice' );
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -559,7 +559,7 @@ class Plugin {
     public function show_admin_notices() {
         if ( ! defined( 'WP_REDIS_DISABLE_BANNERS' ) || ! WP_REDIS_DISABLE_BANNERS ) {
             $this->pro_notice();
-            $this->wc_pro_notice();
+            self::wc_pro_notice();
         }
 
         // Only show admin notices to users with the right capability.
@@ -790,7 +790,7 @@ class Plugin {
      *
      * @return void
      */
-    public function wc_pro_notice() {
+    public static function wc_pro_notice() {
         if ( ! class_exists( 'WooCommerce' ) ) {
             return;
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -104,8 +104,8 @@ class Plugin {
         add_filter( $links, [ self::class, 'add_plugin_actions_links' ] );
 
         add_action( 'wp_head', [ self::class, 'register_shutdown_hooks' ] );
-        add_action( 'shutdown', array( $this, 'record_metrics' ) );
-        add_action( 'rediscache_discard_metrics', array( $this, 'discard_metrics' ) );
+        add_action( 'shutdown', [ self::class, 'record_metrics' ] );
+        add_action( 'rediscache_discard_metrics', [ self::class, 'discard_metrics' ] );
 
         add_filter( 'qm/collectors', [ self::class, 'register_qm_collector' ], 25 );
         add_filter( 'qm/outputter/html', [ self::class, 'register_qm_output' ] );
@@ -841,7 +841,7 @@ class Plugin {
      *
      * @return void
      */
-    public function record_metrics() {
+    public static function record_metrics() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLE_METRICS' ) && WP_REDIS_DISABLE_METRICS ) {
@@ -884,7 +884,7 @@ class Plugin {
      *
      * @return void
      */
-    public function discard_metrics() {
+    public static function discard_metrics() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLE_METRICS' ) && WP_REDIS_DISABLE_METRICS ) {

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -22,14 +22,14 @@ class Plugin {
      *
      * @var string $page
      */
-    private $page = '';
+    private static $page = '';
 
     /**
      * Settings page slug
      *
      * @var string $screen
      */
-    private $screen = '';
+    private static $screen = '';
 
     /**
      * Allowed setting page actions
@@ -70,14 +70,6 @@ class Plugin {
         require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
         register_activation_hook( WP_REDIS_FILE, 'wp_cache_flush' );
-
-        if ( is_multisite() ) {
-            $this->page = 'settings.php?page=redis-cache';
-            $this->screen = 'settings_page_redis-cache-network';
-        } else {
-            $this->page = 'options-general.php?page=redis-cache';
-            $this->screen = 'settings_page_redis-cache';
-        }
 
         $this->add_actions_and_filters();
     }
@@ -230,7 +222,7 @@ class Plugin {
      */
     public function add_plugin_actions_links( $links ) {
         return array_merge(
-            [ sprintf( '<a href="%s">%s</a>', network_admin_url( $this->page ), esc_html__( 'Settings', 'redis-cache' ) ) ],
+            [ sprintf( '<a href="%s">%s</a>', network_admin_url( self::page() ), esc_html__( 'Settings', 'redis-cache' ) ) ],
             $links
         );
     }
@@ -248,7 +240,7 @@ class Plugin {
         }
 
         $screens = [
-            $this->screen,
+            self::screen(),
             'dashboard',
             'dashboard-network',
         ];
@@ -273,7 +265,7 @@ class Plugin {
         }
 
         $screens = [
-            $this->screen,
+            self::screen(),
             'dashboard',
             'dashboard-network',
             'edit-shop_order',
@@ -298,7 +290,7 @@ class Plugin {
             'rediscache',
             [
                 'jQuery' => 'jQuery',
-                'disable_pro' => $screen->id !== $this->screen,
+                'disable_pro' => $screen->id !== self::screen(),
                 'disable_banners' => defined( 'WP_REDIS_DISABLE_BANNERS' ) && WP_REDIS_DISABLE_BANNERS,
                 'l10n' => [
                     'time' => __( 'Time', 'redis-cache' ),
@@ -331,7 +323,7 @@ class Plugin {
             return;
         }
 
-        if ( ! in_array( $screen->id, [ $this->screen, 'dashboard', 'dashboard-network' ], true ) ) {
+        if ( ! in_array( $screen->id, [ self::screen(), 'dashboard', 'dashboard-network' ], true ) ) {
             return;
         }
 
@@ -730,7 +722,7 @@ class Plugin {
                     set_transient( 'settings_errors', $messages, 30 );
 
                     wp_safe_redirect(
-                        network_admin_url( add_query_arg( 'settings-updated', 1, $this->page ) )
+                        network_admin_url( add_query_arg( 'settings-updated', 1, self::page() ) )
                     );
                     exit;
                 }
@@ -789,7 +781,7 @@ class Plugin {
             sprintf(
                 // translators: %s = Link to the plugin setting screen.
                 wp_kses_post( __( 'A <u>business class</u> object cache backend. Truly reliable, highly-optimized and fully customizable, with a <u>dedicated engineer</u> when you most need it. <a href="%s">Learn more »</a>', 'redis-cache' ) ),
-                esc_url( network_admin_url( $this->page ) )
+                esc_url( network_admin_url( self::page() ) )
             )
         );
     }
@@ -829,7 +821,7 @@ class Plugin {
             sprintf(
                 // translators: %s = Link to the plugin's settings screen.
                 wp_kses_post( __( 'Object Cache Pro is a <u>business class</u> object cache that’s highly-optimized for WooCommerce to provide true reliability, peace of mind and faster load times for your store. <a style="color: #bb77ae;" href="%s">Learn more »</a>', 'redis-cache' ) ),
-                esc_url( network_admin_url( $this->page ) )
+                esc_url( network_admin_url( self::page() ) )
             )
         );
     }
@@ -1159,8 +1151,36 @@ class Plugin {
         }
 
         return wp_nonce_url(
-            network_admin_url( add_query_arg( 'action', $action, $this->page ) ),
+            network_admin_url( add_query_arg( 'action', $action, self::page() ) ),
             $action
         );
+    }
+
+    /**
+     * Helper method to determine the settings page url
+     *
+     * @return string
+     */
+    private static function page() {
+        if ( ! self::$page ) {
+            self::$page = is_multisite()
+                ? 'settings.php?page=redis-cache'
+                : 'options-general.php?page=redis-cache';
+        }
+        return self::$page;
+    }
+
+    /**
+     * Helper method to determine the settings screen slug
+     *
+     * @return string
+     */
+    private static function screen() {
+        if ( ! self::$screen ) {
+            self::$screen = is_multisite()
+                ? 'settings_page_redis-cache-network'
+                : 'settings_page_redis-cache';
+        }
+        return self::$screen;
     }
 }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -467,7 +467,7 @@ class Plugin {
      *
      * @return bool|null Boolean Redis connection status if available, null otherwise.
      */
-    public function get_redis_status() {
+    public static function get_redis_status() {
         global $wp_object_cache;
 
         if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {
@@ -848,7 +848,7 @@ class Plugin {
             return;
         }
 
-        if ( ! $this->get_redis_status() ) {
+        if ( ! self::get_redis_status() ) {
             return;
         }
 
@@ -891,7 +891,7 @@ class Plugin {
             return;
         }
 
-        if ( ! $this->get_redis_status() ) {
+        if ( ! self::get_redis_status() ) {
             return;
         }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -410,7 +410,7 @@ class Plugin {
      *
      * @return bool
      */
-    public function validate_object_cache_dropin() {
+    public static function validate_object_cache_dropin() {
         if ( ! self::object_cache_dropin_exists() ) {
             return false;
         }
@@ -457,7 +457,7 @@ class Plugin {
             return __( 'Drop-in not installed', 'redis-cache' );
         }
 
-        if ( ! $this->validate_object_cache_dropin() ) {
+        if ( ! self::validate_object_cache_dropin() ) {
             return __( 'Drop-in is invalid', 'redis-cache' );
         }
 
@@ -482,7 +482,7 @@ class Plugin {
             return;
         }
 
-        if ( ! $this->validate_object_cache_dropin() ) {
+        if ( ! self::validate_object_cache_dropin() ) {
             return;
         }
 
@@ -506,7 +506,7 @@ class Plugin {
             return;
         }
 
-        if ( $this->validate_object_cache_dropin() && method_exists( $wp_object_cache, 'redis_version' ) ) {
+        if ( self::validate_object_cache_dropin() && method_exists( $wp_object_cache, 'redis_version' ) ) {
             return $wp_object_cache->redis_version();
         }
     }
@@ -536,7 +536,7 @@ class Plugin {
     public function get_diagnostics() {
         global $wp_object_cache;
 
-        if ( $this->validate_object_cache_dropin() && property_exists( $wp_object_cache, 'diagnostics' ) ) {
+        if ( self::validate_object_cache_dropin() && property_exists( $wp_object_cache, 'diagnostics' ) ) {
             return $wp_object_cache->diagnostics;
         }
     }
@@ -578,7 +578,7 @@ class Plugin {
         if ( self::object_cache_dropin_exists() ) {
             $url = $this->action_link( 'update-dropin' );
 
-            if ( $this->validate_object_cache_dropin() ) {
+            if ( self::validate_object_cache_dropin() ) {
                 if ( $this->object_cache_dropin_outdated() ) {
                     // translators: %s = Action link to update the drop-in.
                     $message = sprintf( __( 'The Redis object cache drop-in is outdated. Please <a href="%s">update the drop-in</a>.', 'redis-cache' ), $url );
@@ -1097,7 +1097,7 @@ class Plugin {
     public function update_dropin() {
         global $wp_filesystem;
 
-        if ( ! $this->validate_object_cache_dropin() ) {
+        if ( ! self::validate_object_cache_dropin() ) {
             return;
         }
 
@@ -1139,7 +1139,7 @@ class Plugin {
 
             wp_cache_flush();
 
-            if ( $this->validate_object_cache_dropin() && self::initialize_filesystem( '', true ) ) {
+            if ( self::validate_object_cache_dropin() && self::initialize_filesystem( '', true ) ) {
                 $wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
             }
         }

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -44,7 +44,7 @@ class QM_Collector extends Base_Collector {
 
         $roc = Plugin::instance();
 
-        $this->data['status'] = $roc->get_status();
+        $this->data['status'] = Plugin::get_status();
         $this->data['has_dropin'] = Plugin::object_cache_dropin_exists();
         $this->data['valid_dropin'] = Plugin::validate_object_cache_dropin();
 

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -42,8 +42,6 @@ class QM_Collector extends Base_Collector {
 
         $this->process_defaults();
 
-        $roc = Plugin::instance();
-
         $this->data['status'] = Plugin::get_status();
         $this->data['has_dropin'] = Plugin::object_cache_dropin_exists();
         $this->data['valid_dropin'] = Plugin::validate_object_cache_dropin();

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -45,7 +45,7 @@ class QM_Collector extends Base_Collector {
         $roc = Plugin::instance();
 
         $this->data['status'] = $roc->get_status();
-        $this->data['has_dropin'] = $roc->object_cache_dropin_exists();
+        $this->data['has_dropin'] = Plugin::object_cache_dropin_exists();
         $this->data['valid_dropin'] = $roc->validate_object_cache_dropin();
 
         if ( ! method_exists( $wp_object_cache, 'info' ) ) {

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -46,7 +46,7 @@ class QM_Collector extends Base_Collector {
 
         $this->data['status'] = $roc->get_status();
         $this->data['has_dropin'] = Plugin::object_cache_dropin_exists();
-        $this->data['valid_dropin'] = $roc->validate_object_cache_dropin();
+        $this->data['valid_dropin'] = Plugin::validate_object_cache_dropin();
 
         if ( ! method_exists( $wp_object_cache, 'info' ) ) {
             return;

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -50,9 +50,9 @@ class Commands extends WP_CLI_Command {
 
         global $wp_filesystem;
 
-        $plugin = Plugin::instance();
+        if ( Plugin::object_cache_dropin_exists() ) {
 
-        if ( $plugin->object_cache_dropin_exists() ) {
+            $plugin = Plugin::instance();
 
             if ( $plugin->validate_object_cache_dropin() ) {
                 WP_CLI::line( __( 'Redis object cache already enabled.', 'redis-cache' ) );
@@ -95,7 +95,7 @@ class Commands extends WP_CLI_Command {
 
         $plugin = Plugin::instance();
 
-        if ( ! $plugin->object_cache_dropin_exists() ) {
+        if ( ! Plugin::object_cache_dropin_exists() ) {
 
             WP_CLI::error( __( 'No object cache drop-in found.', 'redis-cache' ) );
 

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -31,8 +31,6 @@ class Commands extends WP_CLI_Command {
      *     wp redis status
      */
     public function status() {
-        $roc = Plugin::instance();
-
         require_once __DIR__ . '/../ui/diagnostics.php';
     }
 

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -52,9 +52,7 @@ class Commands extends WP_CLI_Command {
 
         if ( Plugin::object_cache_dropin_exists() ) {
 
-            $plugin = Plugin::instance();
-
-            if ( $plugin->validate_object_cache_dropin() ) {
+            if ( Plugin::validate_object_cache_dropin() ) {
                 WP_CLI::line( __( 'Redis object cache already enabled.', 'redis-cache' ) );
             } else {
                 WP_CLI::error( __( 'A foreign object cache drop-in was found. To use Redis for object caching, run: `wp redis update-dropin`.', 'redis-cache' ) );
@@ -93,15 +91,13 @@ class Commands extends WP_CLI_Command {
 
         global $wp_filesystem;
 
-        $plugin = Plugin::instance();
-
         if ( ! Plugin::object_cache_dropin_exists() ) {
 
             WP_CLI::error( __( 'No object cache drop-in found.', 'redis-cache' ) );
 
         } else {
 
-            if ( ! $plugin->validate_object_cache_dropin() ) {
+            if ( ! Plugin::validate_object_cache_dropin() ) {
 
                 WP_CLI::error( __( 'A foreign object cache drop-in was found. To use Redis for object caching, run: `wp redis update-dropin`.', 'redis-cache' ) );
 

--- a/includes/ui/class-tab.php
+++ b/includes/ui/class-tab.php
@@ -162,8 +162,6 @@ class Tab {
      * @return void
      */
     public function display() {
-        $roc = Plugin::instance();
-
         include $this->file;
     }
 

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -13,7 +13,7 @@ global $wp_object_cache;
 
 $info = [];
 $filesystem = $roc->test_filesystem_writing();
-$dropin = $roc->validate_object_cache_dropin();
+$dropin = Plugin::validate_object_cache_dropin();
 $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 
 $info['Status'] = $roc->get_status();

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -54,7 +54,7 @@ if ( defined( 'HHVM_VERSION' ) ) {
 }
 
 $info['Plugin Version'] = WP_REDIS_VERSION;
-$info['Redis Version'] = $roc->get_redis_version() ?: 'Unknown';
+$info['Redis Version'] = Plugin::get_redis_version() ?: 'Unknown';
 
 $info['Multisite'] = is_multisite() ? 'Yes' : 'No';
 

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -17,7 +17,7 @@ $dropin = Plugin::validate_object_cache_dropin();
 $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 
 $info['Status'] = Plugin::get_status();
-$info['Client'] = $roc->get_redis_client_name();
+$info['Client'] = Plugin::get_redis_client_name();
 $info['Drop-in'] = Plugin::object_cache_dropin_exists()
     ? ( $dropin ? 'Valid' : 'Invalid' )
     : 'Not installed';

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -5,6 +5,8 @@
  * @package Rhubarb\RedisCache
  */
 
+use Rhubarb\RedisCache\Plugin;
+
 defined( '\\ABSPATH' ) || exit;
 
 global $wp_object_cache;
@@ -16,7 +18,7 @@ $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 
 $info['Status'] = $roc->get_status();
 $info['Client'] = $roc->get_redis_client_name();
-$info['Drop-in'] = $roc->object_cache_dropin_exists()
+$info['Drop-in'] = Plugin::object_cache_dropin_exists()
     ? ( $dropin ? 'Valid' : 'Invalid' )
     : 'Not installed';
 $info['Disabled'] = $disabled ? 'Yes' : 'No';

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -16,7 +16,7 @@ $filesystem = Plugin::test_filesystem_writing();
 $dropin = Plugin::validate_object_cache_dropin();
 $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 
-$info['Status'] = $roc->get_status();
+$info['Status'] = Plugin::get_status();
 $info['Client'] = $roc->get_redis_client_name();
 $info['Drop-in'] = Plugin::object_cache_dropin_exists()
     ? ( $dropin ? 'Valid' : 'Invalid' )

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -12,7 +12,7 @@ defined( '\\ABSPATH' ) || exit;
 global $wp_object_cache;
 
 $info = [];
-$filesystem = $roc->test_filesystem_writing();
+$filesystem = Plugin::test_filesystem_writing();
 $dropin = Plugin::validate_object_cache_dropin();
 $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -12,7 +12,7 @@ defined( '\\ABSPATH' ) || exit;
 $redis_client = $roc->get_redis_client_name();
 $redis_prefix = Plugin::get_redis_prefix();
 $redis_maxttl = Plugin::get_redis_maxttl();
-$redis_version = $roc->get_redis_version();
+$redis_version = Plugin::get_redis_version();
 
 $diagnostics = $roc->get_diagnostics();
 

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -10,7 +10,7 @@ use Rhubarb\RedisCache\Plugin;
 defined( '\\ABSPATH' ) || exit;
 
 $redis_client = $roc->get_redis_client_name();
-$redis_prefix = $roc->get_redis_prefix();
+$redis_prefix = Plugin::get_redis_prefix();
 $redis_maxttl = Plugin::get_redis_maxttl();
 $redis_version = $roc->get_redis_version();
 

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -14,7 +14,7 @@ $redis_prefix = Plugin::get_redis_prefix();
 $redis_maxttl = Plugin::get_redis_maxttl();
 $redis_version = Plugin::get_redis_version();
 
-$diagnostics = $roc->get_diagnostics();
+$diagnostics = Plugin::get_diagnostics();
 
 ?>
 

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -236,7 +236,7 @@ $diagnostics = $roc->get_diagnostics();
 
 <p class="submit">
 
-    <?php if ( $roc->get_redis_status() ) : ?>
+    <?php if ( Plugin::get_redis_status() ) : ?>
         <a href="<?php echo esc_attr( Plugin::action_link( 'flush-cache' ) ); ?>" class="button button-primary button-large">
             <?php esc_html_e( 'Flush Cache', 'redis-cache' ); ?>
         </a> &nbsp;

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -237,17 +237,17 @@ $diagnostics = $roc->get_diagnostics();
 <p class="submit">
 
     <?php if ( $roc->get_redis_status() ) : ?>
-        <a href="<?php echo esc_attr( $roc->action_link( 'flush-cache' ) ); ?>" class="button button-primary button-large">
+        <a href="<?php echo esc_attr( Plugin::action_link( 'flush-cache' ) ); ?>" class="button button-primary button-large">
             <?php esc_html_e( 'Flush Cache', 'redis-cache' ); ?>
         </a> &nbsp;
     <?php endif; ?>
 
     <?php if ( Plugin::validate_object_cache_dropin() ) : ?>
-        <a href="<?php echo esc_attr( $roc->action_link( 'disable-cache' ) ); ?>" class="button button-secondary button-large">
+        <a href="<?php echo esc_attr( Plugin::action_link( 'disable-cache' ) ); ?>" class="button button-secondary button-large">
             <?php esc_html_e( 'Disable Object Cache', 'redis-cache' ); ?>
         </a>
     <?php else : ?>
-        <a href="<?php echo esc_attr( $roc->action_link( 'enable-cache' ) ); ?>" class="button button-primary button-large">
+        <a href="<?php echo esc_attr( Plugin::action_link( 'enable-cache' ) ); ?>" class="button button-primary button-large">
             <?php esc_html_e( 'Enable Object Cache', 'redis-cache' ); ?>
         </a>
     <?php endif; ?>

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -9,7 +9,7 @@ use Rhubarb\RedisCache\Plugin;
 
 defined( '\\ABSPATH' ) || exit;
 
-$redis_client = $roc->get_redis_client_name();
+$redis_client = Plugin::get_redis_client_name();
 $redis_prefix = Plugin::get_redis_prefix();
 $redis_maxttl = Plugin::get_redis_maxttl();
 $redis_version = Plugin::get_redis_version();

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -43,7 +43,7 @@ $diagnostics = $roc->get_diagnostics();
                     <?php esc_html_e( 'Outdated', 'redis-cache' ); ?>
                 <?php else : ?>
                     <?php
-                        $roc->validate_object_cache_dropin()
+                        Plugin::validate_object_cache_dropin()
                             ? esc_html_e( 'Valid', 'redis-cache' )
                             : esc_html_e( 'Invalid', 'redis-cache' );
                     ?>
@@ -242,7 +242,7 @@ $diagnostics = $roc->get_diagnostics();
         </a> &nbsp;
     <?php endif; ?>
 
-    <?php if ( $roc->validate_object_cache_dropin() ) : ?>
+    <?php if ( Plugin::validate_object_cache_dropin() ) : ?>
         <a href="<?php echo esc_attr( $roc->action_link( 'disable-cache' ) ); ?>" class="button button-secondary button-large">
             <?php esc_html_e( 'Disable Object Cache', 'redis-cache' ); ?>
         </a>

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -95,7 +95,7 @@ $diagnostics = $roc->get_diagnostics();
 
     <tr>
         <th><?php esc_html_e( 'Status:', 'redis-cache' ); ?></th>
-        <td><code><?php echo esc_html( $roc->get_status() ); ?></code></td>
+        <td><code><?php echo esc_html( Plugin::get_status() ); ?></code></td>
     </tr>
 
     <?php if ( ! empty( $diagnostics['host'] ) ) : ?>

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -11,7 +11,7 @@ defined( '\\ABSPATH' ) || exit;
 
 $redis_client = $roc->get_redis_client_name();
 $redis_prefix = $roc->get_redis_prefix();
-$redis_maxttl = $roc->get_redis_maxttl();
+$redis_maxttl = Plugin::get_redis_maxttl();
 $redis_version = $roc->get_redis_version();
 
 $diagnostics = $roc->get_diagnostics();

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -39,7 +39,7 @@ $diagnostics = $roc->get_diagnostics();
             <code>
                 <?php if ( ! Plugin::object_cache_dropin_exists() ) : ?>
                     <?php esc_html_e( 'Not installed', 'redis-cache' ); ?>
-                <?php elseif ( $roc->object_cache_dropin_outdated() ) : ?>
+                <?php elseif ( Plugin::object_cache_dropin_outdated() ) : ?>
                     <?php esc_html_e( 'Outdated', 'redis-cache' ); ?>
                 <?php else : ?>
                     <?php

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -5,6 +5,8 @@
  * @package Rhubarb\RedisCache
  */
 
+use Rhubarb\RedisCache\Plugin;
+
 defined( '\\ABSPATH' ) || exit;
 
 $redis_client = $roc->get_redis_client_name();
@@ -35,7 +37,7 @@ $diagnostics = $roc->get_diagnostics();
         <th><?php esc_html_e( 'Drop-in:', 'redis-cache' ); ?></th>
         <td>
             <code>
-                <?php if ( ! $roc->object_cache_dropin_exists() ) : ?>
+                <?php if ( ! Plugin::object_cache_dropin_exists() ) : ?>
                     <?php esc_html_e( 'Not installed', 'redis-cache' ); ?>
                 <?php elseif ( $roc->object_cache_dropin_outdated() ) : ?>
                     <?php esc_html_e( 'Outdated', 'redis-cache' ); ?>

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -38,15 +38,4 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     WP_CLI::add_command( 'redis', Rhubarb\RedisCache\CLI\Commands::class );
 }
 
-Rhubarb\RedisCache\Plugin::instance();
-
-if ( ! function_exists( 'redis_object_cache' ) ) {
-    /**
-     * Returns the plugin instance.
-     *
-     * @return Rhubarb\RedisCache\Plugin
-     */
-    function redis_object_cache() {
-        return Rhubarb\RedisCache\Plugin::instance();
-    }
-}
+add_action( 'plugins_loaded', [ Rhubarb\RedisCache\Plugin::class, 'init' ] );


### PR DESCRIPTION
Transformed every method of the plugin class to a static one. Started from the bottom up and replaced all calls as needed.

Introduced getter methods for `Plugin::$screen` and `Plugin::$page` and moved the constructor logic to a new `init` method - scrapped the singleton pattern in the process.

Removed the `redis_object_cache` function as there is no more instance to retrieve.

Changes will satisfy #259 No. 4 and 7 for the plugin class.