### PR TITLE
Credis fatal error fix

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -762,6 +762,16 @@ class WP_Object_Cache {
 
             $this->redis = new Credis_Cluster( $clients );
 
+            foreach ( $clients as &$_client ) {
+                $connection_string = "{$_client['scheme']}://{$_client['host']}:{$_client['port']}";
+                unset( $_client['scheme'], $_client['host'], $_client['port'] );
+                $params = array_filter( $_client );
+                if ( $params ) {
+                    $connection_string .= '?' . http_build_query( $params, null, '&' );
+                }
+                $_client = $connection_string;
+            }
+
             $args['servers'] = $clients;
         } else {
             $args = [

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -745,6 +745,7 @@ class WP_Object_Cache {
             foreach ( $clients as $index => &$connection_string ) {
                 // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
                 $url_components = parse_url( $connection_string );
+
                 parse_str( $url_components['query'], $add_params );
 
                 if ( ! $is_cluster && isset( $add_params['alias'] ) ) {
@@ -765,10 +766,13 @@ class WP_Object_Cache {
             foreach ( $clients as &$_client ) {
                 $connection_string = "{$_client['scheme']}://{$_client['host']}:{$_client['port']}";
                 unset( $_client['scheme'], $_client['host'], $_client['port'] );
+
                 $params = array_filter( $_client );
+
                 if ( $params ) {
                     $connection_string .= '?' . http_build_query( $params, null, '&' );
                 }
+
                 $_client = $connection_string;
             }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -743,7 +743,8 @@ class WP_Object_Cache {
             $clients = $is_cluster ? WP_REDIS_CLUSTER : WP_REDIS_SERVERS;
 
             foreach ( $clients as $index => &$connection_string ) {
-                $url_components = wp_parse_url( $connection_string );
+                // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
+                $url_components = parse_url( $connection_string );
                 parse_str( $url_components['query'], $add_params );
 
                 if ( ! $is_cluster && isset( $add_params['alias'] ) ) {


### PR DESCRIPTION
Introduced in the latest refactoring: `wp_parse_url` is not yet available.

Also fixed the overview displaying `Array` instead of useful information.