### PR TITLE
Fixed an error due to variable referencing

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -742,7 +742,7 @@ class WP_Object_Cache {
             $is_cluster = defined( 'WP_REDIS_CLUSTER' );
             $clients = $is_cluster ? WP_REDIS_CLUSTER : WP_REDIS_SERVERS;
 
-            foreach ( $clients as $index => &$connection_string ) {
+            foreach ( $clients as $index => $connection_string ) {
                 // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
                 $url_components = parse_url( $connection_string );
 
@@ -758,12 +758,12 @@ class WP_Object_Cache {
                     $add_params['alias'] = "redis-$index";
                 }
 
-                $connection_string = array_merge( $parameters, $add_params );
+                $clients[ $index ] = array_merge( $parameters, $add_params );
             }
 
             $this->redis = new Credis_Cluster( $clients );
 
-            foreach ( $clients as &$_client ) {
+            foreach ( $clients as $index => $_client ) {
                 $connection_string = "{$_client['scheme']}://{$_client['host']}:{$_client['port']}";
                 unset( $_client['scheme'], $_client['host'], $_client['port'] );
 
@@ -773,7 +773,7 @@ class WP_Object_Cache {
                     $connection_string .= '?' . http_build_query( $params, null, '&' );
                 }
 
-                $_client = $connection_string;
+                $clients[ $index ] = $connection_string;
             }
 
             $args['servers'] = $clients;


### PR DESCRIPTION
Removed variable referencing in `connect_using_predis` method as it would cause fatals due to repeating referenced variable name `$connection_string` in consecutive `foreach` loops.