### PR TITLE
Metrics custom max time

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -340,7 +340,7 @@ class Plugin {
 
         try {
             $min_time = $sceen->id === $this->screen
-                ? WP_REDIS_METRICS_MAX_TIME
+                ? self::metrics_max_time()
                 : MINUTE_IN_SECONDS * 30;
             $metrics = $wp_object_cache->redis_instance()->zrangebyscore(
                 $wp_object_cache->build_key( 'metrics', 'redis-cache' ),
@@ -902,7 +902,7 @@ class Plugin {
             $wp_object_cache->redis_instance()->zremrangebyscore(
                 $wp_object_cache->build_key( 'metrics', 'redis-cache' ),
                 0,
-                time() - WP_REDIS_METRICS_MAX_TIME
+                time() - self::metrics_max_time()
             );
         } catch ( Exception $exception ) {
             error_log( $exception ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
@@ -968,6 +968,18 @@ class Plugin {
             $message, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             esc_html( $debug )
         );
+    }
+
+    /**
+     * Retrieves metrix max time
+     *
+     * @return int
+     */
+    public static function metrics_max_time() {
+        if ( defined( 'WP_REDIS_METRICS_MAX_TIME' ) ) {
+            return intval( WP_REDIS_METRICS_MAX_TIME );
+        }
+        return HOUR_IN_SECONDS;
     }
 
     /**

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -342,6 +342,7 @@ class Plugin {
             $min_time = $sceen->id === $this->screen
                 ? self::metrics_max_time()
                 : MINUTE_IN_SECONDS * 30;
+
             $metrics = $wp_object_cache->redis_instance()->zrangebyscore(
                 $wp_object_cache->build_key( 'metrics', 'redis-cache' ),
                 time() - $min_time,
@@ -979,6 +980,7 @@ class Plugin {
         if ( defined( 'WP_REDIS_METRICS_MAX_TIME' ) ) {
             return intval( WP_REDIS_METRICS_MAX_TIME );
         }
+
         return HOUR_IN_SECONDS;
     }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -339,7 +339,7 @@ class Plugin {
         }
 
         try {
-            $min_time = $sceen->id === $this->screen
+            $min_time = $screen->id === $this->screen
                 ? self::metrics_max_time()
                 : MINUTE_IN_SECONDS * 30;
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -339,9 +339,12 @@ class Plugin {
         }
 
         try {
+            $min_time = $sceen->id === $this->screen
+                ? WP_REDIS_METRICS_MAX_TIME
+                : MINUTE_IN_SECONDS * 30;
             $metrics = $wp_object_cache->redis_instance()->zrangebyscore(
                 $wp_object_cache->build_key( 'metrics', 'redis-cache' ),
-                time() - ( MINUTE_IN_SECONDS * 30 ),
+                time() - $min_time,
                 time() - MINUTE_IN_SECONDS,
                 [ 'withscores' => true ]
             );
@@ -899,7 +902,7 @@ class Plugin {
             $wp_object_cache->redis_instance()->zremrangebyscore(
                 $wp_object_cache->build_key( 'metrics', 'redis-cache' ),
                 0,
-                time() - HOUR_IN_SECONDS
+                time() - WP_REDIS_METRICS_MAX_TIME
             );
         } catch ( Exception $exception ) {
             error_log( $exception ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -84,6 +84,7 @@ $constants = [
     'WP_REDIS_GLOBAL_GROUPS',
     'WP_REDIS_IGNORED_GROUPS',
     'WP_REDIS_UNFLUSHABLE_GROUPS',
+    'WP_REDIS_METRICS_MAX_TIME',
 ];
 
 foreach ( $constants as $constant ) {

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -28,8 +28,6 @@ $meta = get_file_data( WP_REDIS_FILE, [ 'Version' => 'Version' ] );
 
 define( 'WP_REDIS_VERSION', $meta['Version'] );
 
-defined( 'WP_REDIS_METRICS_MAX_TIME' ) || define( 'WP_REDIS_METRICS_MAX_TIME', HOUR_IN_SECONDS );
-
 require_once WP_REDIS_PLUGIN_PATH . '/includes/class-autoloader.php';
 
 $autoloader = new Rhubarb\RedisCache\Autoloader();

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -28,6 +28,8 @@ $meta = get_file_data( WP_REDIS_FILE, [ 'Version' => 'Version' ] );
 
 define( 'WP_REDIS_VERSION', $meta['Version'] );
 
+defined( 'WP_REDIS_METRICS_MAX_TIME' ) || define( 'WP_REDIS_METRICS_MAX_TIME', HOUR_IN_SECONDS );
+
 require_once WP_REDIS_PLUGIN_PATH . '/includes/class-autoloader.php';
 
 $autoloader = new Rhubarb\RedisCache\Autoloader();


### PR DESCRIPTION
Introduced `WP_REDIS_METRICS_MAX_TIME` constant to define the maximum time metrics should be collected. Default value is 1 hour. The dashboard widget always shows half an hour due to its size restriction.

This might be useful for external metrics collection as well (related: #271)

Constant so far not documented.