### PR TITLE
Adding a filter to Rhubarb\RedisCache\Plugin::validate_object_cache_dropin

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -402,7 +402,7 @@ class Plugin {
         $dropin = get_plugin_data( WP_CONTENT_DIR . '/object-cache.php' );
         $plugin = get_plugin_data( WP_REDIS_PLUGIN_PATH . '/includes/object-cache.php' );
 
-        return $dropin['PluginURI'] === $plugin['PluginURI'];
+        return apply_filters('redis_cache_validate_object_cache_dropin',$dropin['PluginURI'] === $plugin['PluginURI'],$dropin['PluginURI'], $plugin['PluginURI']);
     }
 
     /**


### PR DESCRIPTION
Filter added to Rhubarb\RedisCache\Plugin::validate_object_cache_dropin function

Usage in self coded wp-content/object-cache.php file such as:

`add_filter('redis_cache_validate_object_cache_dropin', function () {
	return true;
}, 10, 2);
require_once 'plugins/redis-cache/includes/object-cache.php';`