### PR TITLE
Dedicated status class

### DIFF
--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -45,8 +45,9 @@ class QM_Collector extends Base_Collector {
         $roc = Plugin::instance();
 
         $this->data['status'] = $roc->get_status();
-        $this->data['has_dropin'] = $roc->object_cache_dropin_exists();
-        $this->data['valid_dropin'] = $roc->validate_object_cache_dropin();
+        $this->data['has_dropin'] = Status::is_dropin_detected();
+        $this->data['dropin_readable'] = Status::is_dropin_readable();
+        $this->data['valid_dropin'] = Status::is_dropin_valid();
 
         if ( ! method_exists( $wp_object_cache, 'info' ) ) {
             return;

--- a/includes/class-status.php
+++ b/includes/class-status.php
@@ -1,0 +1,257 @@
+<?php
+/**
+ * Redis status
+ *
+ * @package Rhubarb\RedisCache
+ */
+
+namespace Rhubarb\RedisCache;
+
+defined( '\\ABSPATH' ) || exit;
+
+/**
+ * Status class
+ */
+class Status {
+
+    const ENABLED = 0;
+    const CONNECTED = 1;
+    const DROPIN_DETECTED = 2;
+    const DROPIN_READABLE = 3;
+    const DROPIN_INSTALLED = 4;
+    const DROPIN_VALID = 5;
+    const DROPIN_UP_TO_DATE = 6;
+
+    /**
+     * Retrieves the current status
+     *
+     * @return int
+     */
+    public static function get() {
+        static $sum;
+        if ( ! isset( $sum ) ) {
+            $sum = 0;
+            foreach ( self::constants() as $test_name => $exp ) {
+                $cb = [ self::class, strtolower( "is_{$test_name}" ) ];
+                if ( is_callable( $cb ) && call_user_func( $cb ) ) {
+                    $sum += pow( 2, $exp );
+                }
+            }
+        }
+        return $sum;
+    }
+
+    /**
+     * Retrieves a human readable status array
+     *
+     * @param bool $invert    Inverts the status only showing failures. Optional. Default `false`.
+     * @param bool $translate Wheather to translate the constants. Optional. Default `false`.
+     * @return array
+     */
+    public static function get_readable(
+        $invert = false,
+        $translate = false
+    ) {
+        $sum = self::get();
+        $constants = self::constants();
+        arsort( $constants );
+        $status = [];
+        foreach ( $constants as $name => $exp ) {
+            $pow = pow( 2, $exp );
+            $result = $sum >= $pow;
+            $status[ $name ] = $result;
+            if ( $result ) {
+                $sum -= $pow;
+            }
+        }
+        if ( $translate ) {
+            foreach ( $status as $key => $value ) {
+                unset( $status[ $key ] );
+                $key = self::translate( $constants[ $key ], $value );
+                $status[ $key ] = $value;
+            }
+        }
+        $status = array_filter(
+            $status,
+            function( $value ) use ( $invert ) {
+                return $invert !== $value;
+            }
+        );
+        return array_keys( $status );
+    }
+
+    /**
+     * Translates a status according to its state
+     *
+     * @param int  $constant One of the status class constants.
+     * @param bool $state    The specific state to translate.
+     * @return string
+     */
+    public static function translate( $constant, $state ) {
+        $translations = [
+            self::ENABLED => [
+                0 => __( 'Disabled', 'redis-cache' ),
+                1 => __( 'Enabled', 'redis-cache' ),
+            ],
+            self::CONNECTED => [
+                0 => __( 'Not conncted', 'redis-cache' ),
+                1 => __( 'Connected', 'redis-cache' ),
+            ],
+            self::DROPIN_DETECTED => [
+                0 => __( 'No Drop-in detected', 'redis-cache' ),
+                1 => __( 'Drop-in detected', 'redis-cache' ),
+            ],
+            self::DROPIN_READABLE => [
+                0 => __( 'Drop-in not readable', 'redis-cache' ),
+                1 => __( 'Drop-in readable', 'redis-cache' ),
+            ],
+            self::DROPIN_INSTALLED => [
+                0 => __( 'A foreign object cache drop-in was found.', 'redis-cache' ),
+                1 => __( 'Drop-in installed', 'redis-cache' ),
+            ],
+            self::DROPIN_VALID => [
+                0 => __( 'Drop-in is invalid', 'redis-cache' ),
+                1 => __( 'Drop-in is valid', 'redis-cache' ),
+            ],
+            self::DROPIN_UP_TO_DATE => [
+                0 => __( 'Disconnected', 'redis-cache' ),
+                1 => __( 'Connected', 'redis-cache' ),
+            ],
+        ];
+
+        if ( isset( $translations[ $constant ][ (int) $state ] ) ) {
+            return $translations[ $constant ][ (int) $state ];
+        }
+
+        return __( 'Unknown', 'redis-cache' );
+    }
+
+    /**
+     * Retrives all class constants
+     *
+     * @return array
+     */
+    private static function constants() {
+        $rc = new \ReflectionClass( self::class );
+        return $rc->getConstants();
+    }
+
+    /**
+     * Returns the drop-in path
+     *
+     * @return string
+     */
+    private static function dropin_path() {
+        return WP_CONTENT_DIR . '/object-cache.php';
+    }
+
+    /**
+     * Utility method to store `get_plugin_data` return
+     *
+     * @param string $path Path of the file to retrieve the plugin data from.
+     * @return array
+     */
+    private static function file_plugin_data( $path ) {
+        static $data = [];
+        if ( ! isset( $data[ $path ] ) ) {
+            $data[ $path ] = get_plugin_data( $path );
+        }
+        return $data[ $path ];
+    }
+
+    /**
+     * Checks if the object cache is enabled
+     */
+    public static function is_enabled() {
+        if ( defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Checks if redis is connected
+     *
+     * @return bool
+     */
+    public static function is_connected() {
+        global $wp_object_cache;
+
+        if ( ! self::is_enabled() || ! self::is_dropin_valid() ) {
+            return false;
+        }
+
+        if ( ! method_exists( $wp_object_cache, 'redis_status' ) ) {
+            return false;
+        }
+
+        return $wp_object_cache->redis_status();
+    }
+
+    /**
+     * Detects if an `object-cache.php` drop-in exists
+     *
+     * @return bool
+     */
+    public static function is_dropin_detected() {
+        return file_exists( self::dropin_path() );
+    }
+
+    /**
+     * Detects if the `object-cache.php` drop-in is readable
+     *
+     * @return bool
+     */
+    public static function is_dropin_readable() {
+        return is_readable( self::dropin_path() );
+    }
+
+    /**
+     * Detects if our `object-cache.php` drop-in is installed
+     *
+     * @return bool
+     */
+    public static function is_dropin_installed() {
+        if ( ! self::is_dropin_readable() ) {
+            return false;
+        }
+
+        $dropin = self::file_plugin_data( self::dropin_path() );
+        $plugin = self::file_plugin_data( WP_REDIS_PLUGIN_PATH . '/includes/object-cache.php' );
+
+        return $dropin['PluginURI'] === $plugin['PluginURI'];
+    }
+
+    /**
+     * Checks if the `object-cache.php` drop-in is up to date
+     *
+     * @return bool
+     */
+    public static function is_dropin_up_to_date() {
+        if ( ! self::is_dropin_readable() ) {
+            return false;
+        }
+
+        $dropin = self::file_plugin_data( self::dropin_path() );
+        $plugin = self::file_plugin_data( WP_REDIS_PLUGIN_PATH . '/includes/object-cache.php' );
+
+        if ( $dropin['PluginURI'] === $plugin['PluginURI'] ) {
+            return $dropin['Version'] === $plugin['Version'];
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks if the `object-cache.php` drop-in is valid
+     *
+     * @return bool
+     */
+    public static function is_dropin_valid() {
+        return self::is_dropin_detected()
+            && self::is_dropin_readable()
+            && self::is_dropin_installed();
+    }
+
+}

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -50,11 +50,9 @@ class Commands extends WP_CLI_Command {
 
         global $wp_filesystem;
 
-        $plugin = Plugin::instance();
+        if ( Status::is_dropin_readable() ) {
 
-        if ( $plugin->object_cache_dropin_exists() ) {
-
-            if ( $plugin->validate_object_cache_dropin() ) {
+            if ( Status::is_dropin_valid() ) {
                 WP_CLI::line( __( 'Redis object cache already enabled.', 'redis-cache' ) );
             } else {
                 WP_CLI::error( __( 'A foreign object cache drop-in was found. To use Redis for object caching, run: `wp redis update-dropin`.', 'redis-cache' ) );
@@ -93,15 +91,13 @@ class Commands extends WP_CLI_Command {
 
         global $wp_filesystem;
 
-        $plugin = Plugin::instance();
-
-        if ( ! $plugin->object_cache_dropin_exists() ) {
+        if ( ! Status::is_dropin_readable() ) {
 
             WP_CLI::error( __( 'No object cache drop-in found.', 'redis-cache' ) );
 
         } else {
 
-            if ( ! $plugin->validate_object_cache_dropin() ) {
+            if ( ! Status::is_dropin_valid() ) {
 
                 WP_CLI::error( __( 'A foreign object cache drop-in was found. To use Redis for object caching, run: `wp redis update-dropin`.', 'redis-cache' ) );
 

--- a/includes/cli/class-commands.php
+++ b/includes/cli/class-commands.php
@@ -13,6 +13,7 @@ use WP_CLI_Command;
 use WP_Filesystem;
 
 use Rhubarb\RedisCache\Plugin;
+use Rhubarb\RedisCache\Status;
 
 defined( '\\ABSPATH' ) || exit;
 

--- a/includes/ui/diagnostics.php
+++ b/includes/ui/diagnostics.php
@@ -7,17 +7,22 @@
 
 defined( '\\ABSPATH' ) || exit;
 
+use Rhubarb\RedisCache\Status;
+
 global $wp_object_cache;
 
 $info = [];
 $filesystem = $roc->test_filesystem_writing();
-$dropin = $roc->validate_object_cache_dropin();
+$dropin = Status::is_dropin_valid();
 $disabled = defined( 'WP_REDIS_DISABLED' ) && WP_REDIS_DISABLED;
 
 $info['Status'] = $roc->get_status();
 $info['Client'] = $roc->get_redis_client_name();
-$info['Drop-in'] = $roc->object_cache_dropin_exists()
-    ? ( $dropin ? 'Valid' : 'Invalid' )
+$info['Drop-in'] = Status::is_dropin_detected()
+    ? ( Status::is_dropin_readable()
+        ? ( $dropin ? 'Valid' : 'Invalid' )
+        : 'Unreadable'
+    )
     : 'Not installed';
 $info['Disabled'] = $disabled ? 'Yes' : 'No';
 $info['Filesystem'] = is_wp_error( $filesystem ) ? $filesystem->get_error_message() : 'Working';

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -7,6 +7,8 @@
 
 defined( '\\ABSPATH' ) || exit;
 
+use Rhubarb\RedisCache\Status;
+
 $redis_client = $roc->get_redis_client_name();
 $redis_prefix = $roc->get_redis_prefix();
 $redis_maxttl = $roc->get_redis_maxttl();
@@ -35,13 +37,15 @@ $diagnostics = $roc->get_diagnostics();
         <th><?php esc_html_e( 'Drop-in:', 'redis-cache' ); ?></th>
         <td>
             <code>
-                <?php if ( ! $roc->object_cache_dropin_exists() ) : ?>
+                <?php if ( ! Status::is_dropin_detected() ) : ?>
                     <?php esc_html_e( 'Not installed', 'redis-cache' ); ?>
-                <?php elseif ( $roc->object_cache_dropin_outdated() ) : ?>
+                <?php elseif ( ! Status::is_dropin_readable() ) : ?>
+                    <?php esc_html_e( 'Unreadable', 'redis-cache' ); ?>
+                <?php elseif ( ! Status::is_dropin_up_to_date() ) : ?>
                     <?php esc_html_e( 'Outdated', 'redis-cache' ); ?>
                 <?php else : ?>
                     <?php
-                        $roc->validate_object_cache_dropin()
+                        Status::is_dropin_valid()
                             ? esc_html_e( 'Valid', 'redis-cache' )
                             : esc_html_e( 'Invalid', 'redis-cache' );
                     ?>
@@ -240,7 +244,7 @@ $diagnostics = $roc->get_diagnostics();
         </a> &nbsp;
     <?php endif; ?>
 
-    <?php if ( $roc->validate_object_cache_dropin() ) : ?>
+    <?php if ( Status::is_dropin_valid() ) : ?>
         <a href="<?php echo esc_attr( $roc->action_link( 'disable-cache' ) ); ?>" class="button button-secondary button-large">
             <?php esc_html_e( 'Disable Object Cache', 'redis-cache' ); ?>
         </a>


### PR DESCRIPTION
* Encapsulated most of the drop-in states as well as a general enabled and connected into a dedicated class
* Multiple error messages can be returned using this approach
* Added `dropin_detected` state for cases where a drop-in is present but not necessarily readable
* Deprecated the status methods in the Plugin class using a new `deprecated_function` method. Deprecation version information set to `2.1.0`
* `Plugin::get_status()` could be marked as deprecated if we would switch to `Status::get_readable( true ) ?: __( 'OK', 'redis-cache' )` 
* Deprecation function heavily borrows from WooCommerce
* Precursor to REST API (PR once this PR is merged)

Need Feedback