### PR TITLE
Fix cache time's type in WP_Object_Cache

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -380,7 +380,7 @@ class WP_Object_Cache {
     /**
      * Track how long request took.
      *
-     * @var int
+     * @var float
      */
     public $cache_time = 0;
 


### PR DESCRIPTION
A `float` is put in it everywhere.