### PR TITLE
Do not display the dropin message if redis is disabled.

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -571,6 +571,11 @@ class Plugin {
         if ( ! current_user_can( is_multisite() ? 'manage_network_options' : 'manage_options' ) ) {
             return;
         }
+        
+        // Do not display the dropin message if redis is disabled.
+        if (defined('WP_REDIS_DISABLED') && WP_REDIS_DISABLED) {
+            return;
+        }
 
         if ( $this->object_cache_dropin_exists() ) {
             $url = $this->action_link( 'update-dropin' );


### PR DESCRIPTION
I would like to control when I can replace object-cache.php. As long as WP_REDIS_DISABLED, I want to be sure that no user of my site can overwrite object-cache.php (we are several admin)