### PR TITLE
Do not display the dropin message if WP_REDIS_DISABLE_DROPIN_BANNERS …

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -571,6 +571,11 @@ class Plugin {
         if ( ! current_user_can( is_multisite() ? 'manage_network_options' : 'manage_options' ) ) {
             return;
         }
+        
+        // Do not display the dropin message if you want
+        if (defined('WP_REDIS_DISABLE_DROPIN_BANNERS') && WP_REDIS_DISABLE_DROPIN_BANNERS) {
+            return;
+        }
 
         if ( $this->object_cache_dropin_exists() ) {
             $url = $this->action_link( 'update-dropin' );

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -573,7 +573,7 @@ class Plugin {
         }
         
         // Do not display the dropin message if you want
-        if (defined('WP_REDIS_DISABLE_DROPIN_BANNERS') && WP_REDIS_DISABLE_DROPIN_BANNERS) {
+        if ( defined( 'WP_REDIS_DISABLE_DROPIN_BANNERS' ) && WP_REDIS_DISABLE_DROPIN_BANNERS ) {
             return;
         }
 


### PR DESCRIPTION
…exists and true.

I would like to control when I can replace object-cache.php. As long as WP_REDIS_DISABLE_DROPIN_BANNERS, I want to be sure that no user of my site can overwrite object-cache.php (we are several admin)