### PR TITLE
add 'redis_object_cache_trace' hook. Enables tracing of every call, useful for fine grained metric collection

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1068,7 +1068,7 @@ class WP_Object_Cache {
                         'value' => $value,
                         'status' => self::TRACE_FLAG_WRITE,
                     ],
-                ], microtime(true) - $start_time );
+                ], microtime( true ) - $start_time );
 
                 $this->cache_calls++;
                 $this->cache_time += $execute_time;
@@ -1408,7 +1408,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_HIT | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], microtime(true) - $start_time);
+            ], microtime( true ) - $start_time);
 
             return $value;
         } elseif ( $this->is_ignored_group( $group ) || ! $this->redis_status() ) {
@@ -1420,7 +1420,7 @@ LUA;
                     'value' => null,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], microtime(true) - $start_time );
+            ], microtime( true ) - $start_time );
 
             return false;
         }
@@ -1448,7 +1448,7 @@ LUA;
                     'value' => null,
                     'status' => $trace_flags,
                 ],
-            ], microtime(true) - $start_time );
+            ], microtime( true ) - $start_time );
             return false;
         } else {
             $found = true;
@@ -1463,7 +1463,7 @@ LUA;
                 'value' => $value,
                 'status' => $trace_flags | self::TRACE_FLAG_HIT,
             ],
-        ], microtime(true) - $start_time );
+        ], microtime( true ) - $start_time );
 
         if ( function_exists( 'do_action' ) ) {
             /**
@@ -1521,7 +1521,7 @@ LUA;
 
         $cache = [];
         $derived_keys = [];
-        $start_time = microtime(true);
+        $start_time = microtime( true );
 
         foreach ( $keys as $key ) {
             $derived_keys[ $key ] = $this->build_key( $key, $group );
@@ -1557,7 +1557,7 @@ LUA;
                 }
             }
 
-            $this->trace_command( 'mget', $group, $traceKV, microtime(true) - $start_time );
+            $this->trace_command( 'mget', $group, $traceKV, microtime( true ) - $start_time );
 
             return $cache;
         }
@@ -1599,7 +1599,7 @@ LUA;
         );
 
         if ( empty( $remaining_keys ) ) {
-            $this->trace_command( 'mget', $group, $traceKV, microtime(true) - $start_time );
+            $this->trace_command( 'mget', $group, $traceKV, microtime( true ) - $start_time );
 
             return $cache;
         }
@@ -1796,7 +1796,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], microtime(true) - $start_time );
+            ], microtime( true ) - $start_time );
 
             return $value;
         }
@@ -1864,7 +1864,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], microtime(true) - $start_time );
+            ], microtime( true ) - $start_time );
 
             return $value;
         }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -259,42 +259,42 @@ class WP_Object_Cache {
     /**
      * Operation pertains to internal cache, not Redis.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_INTERNAL = 1 << 0;
     /**
      * Operation resulted in a cache hit.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_HIT = 1 << 1;
     /**
      * Read operation.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_READ = 1 << 2;
     /**
      * Write operation.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_WRITE = 1 << 3;
     /**
      * Delete operation.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_DEL = 1 << 4;
     /**
      * Operation bypassed internal cache.
      *
-     * @since x.x.x
+     * @since 2.0.18
      * @var int
      */
     const TRACE_FLAG_REFRESH = 1 << 5;

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1068,7 +1068,7 @@ class WP_Object_Cache {
                         'value' => $value,
                         'status' => self::TRACE_FLAG_WRITE,
                     ],
-                ], $this->elapsed( $start_time ) );
+                ], microtime(true) - $start_time );
 
                 $this->cache_calls++;
                 $this->cache_time += $execute_time;
@@ -1408,7 +1408,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_HIT | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], $this->elapsed($start_time));
+            ], microtime(true) - $start_time);
 
             return $value;
         } elseif ( $this->is_ignored_group( $group ) || ! $this->redis_status() ) {
@@ -1420,7 +1420,7 @@ LUA;
                     'value' => null,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], $this->elapsed( $start_time ) );
+            ], microtime(true) - $start_time );
 
             return false;
         }
@@ -1448,7 +1448,7 @@ LUA;
                     'value' => null,
                     'status' => $trace_flags,
                 ],
-            ], $this->elapsed( $start_time ) );
+            ], microtime(true) - $start_time );
             return false;
         } else {
             $found = true;
@@ -1463,7 +1463,7 @@ LUA;
                 'value' => $value,
                 'status' => $trace_flags | self::TRACE_FLAG_HIT,
             ],
-        ], $this->elapsed( $start_time ) );
+        ], microtime(true) - $start_time );
 
         if ( function_exists( 'do_action' ) ) {
             /**
@@ -1557,7 +1557,7 @@ LUA;
                 }
             }
 
-            $this->trace_command( 'mget', $group, $traceKV, $this->elapsed( $start_time ) );
+            $this->trace_command( 'mget', $group, $traceKV, microtime(true) - $start_time );
 
             return $cache;
         }
@@ -1599,7 +1599,7 @@ LUA;
         );
 
         if ( empty( $remaining_keys ) ) {
-            $this->trace_command( 'mget', $group, $traceKV, $this->elapsed( $start_time ) );
+            $this->trace_command( 'mget', $group, $traceKV, microtime(true) - $start_time );
 
             return $cache;
         }
@@ -1796,7 +1796,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], $this->elapsed( $start_time ) );
+            ], microtime(true) - $start_time );
 
             return $value;
         }
@@ -1864,7 +1864,7 @@ LUA;
                     'value' => $value,
                     'status' => $trace_flags | self::TRACE_FLAG_INTERNAL,
                 ],
-            ], $this->elapsed( $start_time ) );
+            ], microtime(true) - $start_time );
 
             return $value;
         }
@@ -2329,16 +2329,6 @@ LUA;
      */
     public function __get( $name ) {
         return isset( $this->{$name} ) ? $this->{$name} : null;
-    }
-
-    /**
-     * Calculates how much time has elapsed since $start_time.
-     *
-     * @param float $start_time
-     * @return float
-     */
-    private function elapsed( $start_time ) {
-        return microtime(true) - $start_time;
     }
 
     /**


### PR DESCRIPTION
The proposal is simple, add a new hook that reports statistics (hits & misses) for every cache call.

This enables end users to implement fine grained metrics in order to better understand cache runtime behaviour, in order to optimize cache usage.

The proposed signature is as follows:
```php
/**
    * Fires on every cache call.
    *
    * This hook is called on every cache request.
    * It reports statistics per key involved. @see WP_Object_Cache::TRACE_FLAG_READ and friends.
    *
    * @param  string             $command   The command that was executed.
    * @param  string             $group     Key group.
    * @param  array[string]array $keyValues Maps keys to the returned values (if any) and the resulting status.
    *  $keyValues = [
    *      "foo" => ["value" => "bar", "status" => TRACE_FLAG_READ | TRACE_FLAG_HIT],                       // hit on redis (implies internal miss)
    *      "baz" => ["value" => "quo", "status" => TRACE_FLAG_READ | TRACE_FLAG_HIT | TRACE_FLAG_INTERNAL], // hit on internal cache
    *      "eta" => ["value" => null,  "status" => TRACE_FLAG_READ],                                        // miss
    * ];
    * @param  float              $duration  Duration of the request in microseconds.
    * @return void
*/
do_action( 'redis_object_cache_trace', $command, $group, $keyValues, $duration );
```

This signature is able to accommodate for both batch and single key flows.
For every key, we pass the value as well as the operation metadata to the user. The user is free to decide which metadata is relevant for their use case.

Flags are defined as follows:
```php
/**
    * Operation pertains to internal cache, not Redis.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_INTERNAL = 1 << 0;
/**
    * Operation resulted in a cache hit.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_HIT = 1 << 1;
/**
    * Read operation.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_READ = 1 << 2;
/**
    * Write operation.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_WRITE = 1 << 3;
/**
    * Delete operation.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_DEL = 1 << 4;
/**
    * Operation bypassed internal cache.
    *
    * @since x.x.x
    * @var int
*/
const TRACE_FLAG_REFRESH = 1 << 5;
```

Intended usage is as follows:
```php
add_action( 'redis_object_cache_trace', function($command, $group, $keyValues, $duration) {
    foreach ($keyValues as $key => $result) {
        $flags = $result['status'];
        $value = $result['value'];
       
        $isInternal = ($flags & WP_Object_Cache::TRACE_FLAG_INTERNAL) > 0;
        $isHit = ($flags & WP_Object_Cache::TRACE_FLAG_HIT) > 0;
        $isReadOp = ($flags & WP_Object_Cache::TRACE_FLAG_READ) > 0;
        $isWriteOp = ($flags & WP_Object_Cache::TRACE_FLAG_WRITE) > 0;
        $isDelOp = ($flags & WP_Object_Cache::TRACE_FLAG_DEL) > 0;
        $isRefresh = ($flags & WP_Object_Cache::TRACE_FLAG_REFRESH) > 0;

        
        // do stuff.
    }
}, 10, 4);
```

We decided to ignore writes to the internal cache, as we don't see any value in measuring it. If you feel like we should, even if it's for the sake of consistency alone, let us know.

I'm not a PHP developer, nor am I that familiar with WP, so please let me know if there's anything that can be improved.
