### PR TITLE
Set unique `WP_CACHE_KEY_SALT` for sites hosted on Cloudways

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -160,6 +160,11 @@ function wp_cache_init() {
         define( 'WP_REDIS_SELECTIVE_FLUSH', (bool) getenv( 'WP_REDIS_SELECTIVE_FLUSH' ) );
     }
 
+    // Set unique `WP_CACHE_KEY_SALT` for sites hosted on Cloudways  
+    if( ( ! defined( 'WP_CACHE_KEY_SALT' ) ) && ( isset( $_SERVER['cw_allowed_ip'] ) ))  {
+        define( 'WP_CACHE_KEY_SALT', getenv(HTTP_X_APP_USER) );
+    }
+
     // Backwards compatibility: map `WP_CACHE_KEY_SALT` constant to `WP_REDIS_PREFIX`.
     if ( defined( 'WP_CACHE_KEY_SALT' ) && ! defined( 'WP_REDIS_PREFIX' ) ) {
         define( 'WP_REDIS_PREFIX', WP_CACHE_KEY_SALT );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -160,14 +160,14 @@ function wp_cache_init() {
         define( 'WP_REDIS_SELECTIVE_FLUSH', (bool) getenv( 'WP_REDIS_SELECTIVE_FLUSH' ) );
     }
 
-    // Set unique `WP_CACHE_KEY_SALT` for sites hosted on Cloudways  
-    if( ( ! defined( 'WP_CACHE_KEY_SALT' ) ) && ( isset( $_SERVER['cw_allowed_ip'] ) ))  {
-        define( 'WP_CACHE_KEY_SALT', getenv(HTTP_X_APP_USER) );
-    }
-
     // Backwards compatibility: map `WP_CACHE_KEY_SALT` constant to `WP_REDIS_PREFIX`.
     if ( defined( 'WP_CACHE_KEY_SALT' ) && ! defined( 'WP_REDIS_PREFIX' ) ) {
         define( 'WP_REDIS_PREFIX', WP_CACHE_KEY_SALT );
+    }
+    
+    // Set unique `WP_CACHE_KEY_SALT` for sites hosted on Cloudways  
+    if ( ! defined( 'WP_REDIS_PREFIX' ) && isset( $_SERVER['cw_allowed_ip'] ) )  {
+        define( 'WP_REDIS_PREFIX', getenv( 'HTTP_X_APP_USER' ) );
     }
 
     if ( ! ( $wp_object_cache instanceof WP_Object_Cache ) ) {


### PR DESCRIPTION
The above code ensure a unique key salt prefix for customers hosting multiple sites on the same Cloudways server, the code checks if the site is hosted on a Cloudways environment along with if the WP_CACHE_KEY_SALT is defined in wp-config.php or not.  if key prefix is not defined and site is hosted on Cloudways the unique key-prefix will be set automatically by the plugin.