### PR TITLE
fix: prevent errors on diagnostics page if the plugin is disabled

### DIFF
--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -63,7 +63,7 @@ $info['Metrics recorded'] = wp_json_encode( \Rhubarb\RedisCache\Metrics::count()
 
 $info['Filesystem'] = is_wp_error( $filesystem ) ? $filesystem->get_error_message() : 'Working';
 
-if ( $dropin && !$disabled ) {
+if ( $dropin && ! $disabled ) {
     $info['Global Prefix'] = wp_json_encode( $wp_object_cache->global_prefix );
     $info['Blog Prefix'] = wp_json_encode( $wp_object_cache->blog_prefix );
 }
@@ -117,7 +117,7 @@ if ( defined( 'WP_REDIS_PASSWORD' ) ) {
     }
 }
 
-if ( $dropin && !$disabled ) {
+if ( $dropin && ! $disabled ) {
     $info['Global Groups'] = wp_json_encode(
         array_values( $wp_object_cache->global_groups ),
         JSON_PRETTY_PRINT

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -63,7 +63,7 @@ $info['Metrics recorded'] = wp_json_encode( \Rhubarb\RedisCache\Metrics::count()
 
 $info['Filesystem'] = is_wp_error( $filesystem ) ? $filesystem->get_error_message() : 'Working';
 
-if ( $dropin ) {
+if ( $dropin && !$disabled ) {
     $info['Global Prefix'] = wp_json_encode( $wp_object_cache->global_prefix );
     $info['Blog Prefix'] = wp_json_encode( $wp_object_cache->blog_prefix );
 }
@@ -117,7 +117,7 @@ if ( defined( 'WP_REDIS_PASSWORD' ) ) {
     }
 }
 
-if ( $dropin ) {
+if ( $dropin && !$disabled ) {
     $info['Global Groups'] = wp_json_encode(
         array_values( $wp_object_cache->global_groups ),
         JSON_PRETTY_PRINT


### PR DESCRIPTION
If the plugin is disabled via `WP_REDIS_DISABLED`, then errors like this are thrown on the diagnostic page:

`An error of type E_ERROR was caused in line 127 of the file /path/to/redis-cache/includes/diagnostics.php`


`Error message: Uncaught TypeError: array_values(): Argument #1 ($array) must be of type array, null`

This prevents them.