### PR TITLE
Implementing Github actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,133 @@
+name: Run Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  single-instance:
+    name: Testing (PHP ${{ matrix.php }}; Instance ${{ matrix.redis }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - '3306:3306'
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_DATABASE: wordpress_test
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        composer: ['composer:v2.2', 'composer']
+        redis: [ '4.0.14', '5.0.12', '6.2.6' ]
+        include:
+          - composer: 'composer'
+          - php: '7.1'
+            composer: 'composer:v2.2'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Build Redis instance
+        uses: getong/redis-action@v1
+        with:
+          redis version: ${{ matrix.redis }}
+          host port: 6379
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: msgpack, igbinary, redis-5.3.7
+          tools: ${{ matrix.composer }}
+
+      - name: Set up WordPress and WordPress Test Library
+        uses: sjinks/setup-wordpress-test-library@master
+        with:
+          version: latest
+
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Install missing library
+        run: |
+          composer require --dev yoast/phpunit-polyfills
+
+      - name: Verify MySQL connection
+        run: |
+          while ! mysqladmin ping -h 127.0.0.1 -P ${{ job.services.mysql.ports[3306] }} --silent; do
+            sleep 1
+          done
+        timeout-minutes: 1
+
+      - name: Run test suite
+        run: ./vendor/bin/phpunit
+
+  cluster-instance:
+    name: Testing (PHP ${{ matrix.php }}; Cluster ${{ matrix.redis }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    services:
+      mysql:
+        image: mysql:5.7
+        ports:
+          - '3306:3306'
+        env:
+          MYSQL_ROOT_PASSWORD: wordpress
+          MYSQL_USER: wordpress
+          MYSQL_PASSWORD: wordpress
+          MYSQL_DATABASE: wordpress_test
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '7.1', '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        composer: ['composer:v2.2', 'composer']
+        redis: [ '5.0.12', '6.2.1' ]
+        include:
+          - composer: 'composer'
+          - php: '7.1'
+            composer: 'composer:v2.2'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Build Redis cluster
+        uses: brunoofarias-dev/redis-cluster-github-action@main
+        with:
+          redis-version: ${{ matrix.redis }}
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: msgpack, igbinary, redis-5.3.7
+          tools: ${{ matrix.composer }}
+
+      - name: Set up WordPress and WordPress Test Library
+        uses: sjinks/setup-wordpress-test-library@master
+        with:
+          version: latest
+
+      - name: Install PHP Dependencies
+        uses: ramsey/composer-install@v2
+
+      - name: Install missing library
+        run: |
+          composer require --dev yoast/phpunit-polyfills
+
+      - name: Verify MySQL connection
+        run: |
+          while ! mysqladmin ping -h 127.0.0.1 -P ${{ job.services.mysql.ports[3306] }} --silent; do
+            sleep 1
+          done
+        timeout-minutes: 1
+
+      - name: Run test suite
+        run: ./vendor/bin/phpunit

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * Plugin Name: Redis Object Cache Drop-In
- * Plugin URI: http://wordpress.org/plugins/redis-cache/
- * Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, Credis, HHVM, replication, clustering and WP-CLI.
+ * Plugin URI: https://wordpress.org/plugins/redis-cache/
+ * Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, Relay, Credis, HHVM, replication, clustering and WP-CLI.
  * Version: 2.0.26
  * Author: Till Krüss
  * Author URI: https://objectcache.pro

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -11,7 +11,12 @@ $GLOBALS['wp_tests_options'] = [
     ],
 ];
 
-$_tests_dir = '/opt/bitnami/wordpress/tests-lib';
+$_tests_dir = getenv('WP_TESTS_DIR');
+
+if ( ! getenv('WP_TESTS_DIR') ) {
+    $_tests_dir = '/opt/bitnami/wordpress/tests-lib';
+}
+
 $base_dir   = dirname( dirname( __DIR__ ) );
 
 // Give access to tests_add_filter() function.

--- a/tests/phpunit/cache/class-cache-test.php
+++ b/tests/phpunit/cache/class-cache-test.php
@@ -6,14 +6,14 @@
 class Cache_Test extends WP_UnitTestCase {
 	public $cache = null;
 
-	function setUp() {
+	function setUp(): void {
 		parent::setUp();
 		// Create two cache objects with a shared cache directory.
 		// This simulates a typical cache situation, two separate requests interacting.
 		$this->cache =& $this->init_cache();
 	}
 
-	function tearDown() {
+	function tearDown(): void {
 		$this->flush_cache();
 		parent::tearDown();
 	}
@@ -26,11 +26,11 @@ class Cache_Test extends WP_UnitTestCase {
 		return $cache;
 	}
 
-	function test_miss() {
+	function test_miss(): void {
 		$this->assertFalse( $this->cache->get( 'test_miss' ) );
 	}
 
-	function test_add_get() {
+	function test_add_get(): void {
 		$key = __FUNCTION__;
 		$val = 'val';
 
@@ -38,7 +38,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val, $this->cache->get( $key ) );
 	}
 
-	function test_add_get_0() {
+	function test_add_get_0(): void {
 		$key = __FUNCTION__;
 		$val = 0;
 
@@ -50,7 +50,7 @@ class Cache_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 20004
 	 */
-	function test_add_get_null() {
+	function test_add_get_null(): void {
 		$key = __FUNCTION__;
 		$val = null;
 
@@ -62,7 +62,7 @@ class Cache_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 20004
 	 */
-	function test_add_get_false() {
+	function test_add_get_false(): void {
 		$key = __FUNCTION__;
 		$val = false;
 
@@ -71,7 +71,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val, $this->cache->get( $key ) );
 	}
 
-	function test_add() {
+	function test_add(): void {
 		$key  = __FUNCTION__;
 		$val1 = 'val1';
 		$val2 = 'val2';
@@ -84,7 +84,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val1, $this->cache->get( $key ) );
 	}
 
-	function test_replace() {
+	function test_replace(): void {
 		$key  = __FUNCTION__;
 		$val  = 'val1';
 		$val2 = 'val2';
@@ -98,7 +98,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val2, $this->cache->get( $key ) );
 	}
 
-	function test_set() {
+	function test_set(): void {
 		$key  = __FUNCTION__;
 		$val1 = 'val1';
 		$val2 = 'val2';
@@ -111,7 +111,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val2, $this->cache->get( $key ) );
 	}
 
-	function test_flush() {
+	function test_flush(): void {
 		global $_wp_using_ext_object_cache;
 
 		if ( $_wp_using_ext_object_cache ) {
@@ -130,7 +130,7 @@ class Cache_Test extends WP_UnitTestCase {
 	}
 
 	// Make sure objects are cloned going to and from the cache.
-	function test_object_refs() {
+	function test_object_refs(): void {
 		$key           = __FUNCTION__ . '_1';
 		$object_a      = new stdClass;
 		$object_a->foo = 'alpha';
@@ -152,7 +152,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( 'bravo', $object_a->foo );
 	}
 
-	function test_incr() {
+	function test_incr(): void {
 		$key = __FUNCTION__;
 
 		$this->assertFalse( $this->cache->incr( $key ) );
@@ -165,7 +165,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( 3, $this->cache->get( $key ) );
 	}
 
-	function test_wp_cache_incr() {
+	function test_wp_cache_incr(): void {
 		$key = __FUNCTION__;
 
 		$this->assertFalse( wp_cache_incr( $key ) );
@@ -178,7 +178,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( 3, wp_cache_get( $key ) );
 	}
 
-	function test_decr() {
+	function test_decr(): void {
 		$key = __FUNCTION__;
 
 		$this->assertFalse( $this->cache->decr( $key ) );
@@ -198,7 +198,7 @@ class Cache_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 21327
 	 */
-	function test_wp_cache_decr() {
+	function test_wp_cache_decr(): void {
 		$key = __FUNCTION__;
 
 		$this->assertFalse( wp_cache_decr( $key ) );
@@ -215,7 +215,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( 0, wp_cache_get( $key ) );
 	}
 
-	function test_delete() {
+	function test_delete(): void {
 		$key = __FUNCTION__;
 		$val = 'val';
 
@@ -230,7 +230,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertFalse( $this->cache->delete( $key, 'default' ) );
 	}
 
-	function test_wp_cache_delete() {
+	function test_wp_cache_delete(): void {
 		$key = __FUNCTION__;
 		$val = 'val';
 
@@ -249,7 +249,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_cache_delete( $key, 'default' ) );
 	}
 
-	function test_switch_to_blog() {
+	function test_switch_to_blog(): void {
 		if ( ! method_exists( $this->cache, 'switch_to_blog' ) ) {
 			$this->markTestSkipped( 'This test requires a switch_to_blog() method on the cache object.' );
 		}
@@ -295,7 +295,7 @@ class Cache_Test extends WP_UnitTestCase {
 		$this->assertSame( $val2, $this->cache->get( $key, 'global-cache-test' ) );
 	}
 
-	function test_wp_cache_init() {
+	function test_wp_cache_init(): void {
 		$new_blank_cache_object = new WP_Object_Cache();
 		wp_cache_init();
 
@@ -309,7 +309,7 @@ class Cache_Test extends WP_UnitTestCase {
 		}
 	}
 
-	function test_wp_cache_replace() {
+	function test_wp_cache_replace(): void {
 		$key  = 'my-key';
 		$val1 = 'first-val';
 		$val2 = 'second-val';
@@ -334,7 +334,7 @@ class Cache_Test extends WP_UnitTestCase {
 	/**
 	 * @ticket 20875
 	 */
-	public function test_get_multiple() {
+	public function test_get_multiple(): void {
 		wp_cache_set( 'foo1', 'bar', 'group1' );
 		wp_cache_set( 'foo2', 'bar', 'group1' );
 		wp_cache_set( 'foo1', 'bar', 'group2' );


### PR DESCRIPTION
This PR adds the ability to run the tests using github actions, instead of depending only on the Docker implementation.

Tests are done with the following matrix
- PHP 7.1 - 8.1
- Redis: 4,5,6 for single instance and 5,6 for clusters.