### PR TITLE
[WIP] fix the connectionID value when connecting to cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+- Improve cluster information readability inside the diagnostics tab.
+- Fixed the connection id when trying to ping the server in `__construct`.
+- Fixed the cluster array in `connect_using_phpredis`.
+- Fixed the cluster array in `connect_using_predis`.
+- Fixed a few bugs in `connect_using_credis`.
+- Fixed the connection id in `fetch_info`.
+- Added a note about the deprecation of HHVM and Credis.
+- Added an internal function `build_cluster_connection_array` to return the correct format for the clusters.
+
 ## 2.0.26
 
 - Fixed a bug in `wp_cache_delete_multiple()` when using Predis

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -43,7 +43,6 @@ if ( $dropin && ! $disabled ) {
 $info['PhpRedis'] = class_exists( 'Redis' ) ? phpversion( 'redis' ) : 'Not loaded';
 $info['Relay'] = class_exists( 'Relay\Relay' ) ? phpversion( 'relay' ) : 'Not loaded';
 $info['Predis'] = class_exists( 'Predis\Client' ) ? Predis\Client::VERSION : 'Not loaded';
-$info['Credis'] = class_exists( 'Credis_Client' ) ? Credis_Client::VERSION : 'Not loaded';
 
 if ( defined( 'PHP_VERSION' ) ) {
     $info['PHP Version'] = PHP_VERSION;
@@ -98,7 +97,7 @@ foreach ( $constants as $constant ) {
     if ( defined( $constant ) ) {
         $info[ $constant ] = wp_json_encode(
             constant( $constant ),
-            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT
         );
     }
 }

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -43,6 +43,7 @@ if ( $dropin && ! $disabled ) {
 $info['PhpRedis'] = class_exists( 'Redis' ) ? phpversion( 'redis' ) : 'Not loaded';
 $info['Relay'] = class_exists( 'Relay\Relay' ) ? phpversion( 'relay' ) : 'Not loaded';
 $info['Predis'] = class_exists( 'Predis\Client' ) ? Predis\Client::VERSION : 'Not loaded';
+$info['Credis'] = class_exists( 'Credis_Client' ) ? Credis_Client::VERSION : 'Not loaded';
 
 if ( defined( 'PHP_VERSION' ) ) {
     $info['PHP Version'] = PHP_VERSION;

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2764,14 +2764,13 @@ LUA;
      */
     public function build_cluster_connection_array() {
         $cluster = array_values( WP_REDIS_CLUSTER );
-        $currentServer = current( $cluster );
-        $scheme = sprintf( '%s://' , current( explode( '://' , $currentServer ) ) );
 
         foreach ( $cluster as $key => $server ) {
-            $cluster[ $key ] = current(
-                explode( '?' ,
-                    str_replace( $scheme , '' , $server )
-                )
+            $connection_string = parse_url( $server );
+            $cluster[ $key ] = sprintf(
+                "%s:%s",
+                $connection_string[ 'host' ],
+                $connection_string[ 'port' ]
             );
         }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Redis Object Cache Drop-In
  * Plugin URI: https://wordpress.org/plugins/redis-cache/
- * Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, Relay, HHVM, replication, clustering and WP-CLI.
+ * Description: A persistent object cache backend powered by Redis. Supports Predis, PhpRedis, Relay, replication, clustering and WP-CLI.
  * Version: 2.0.26
  * Author: Till Krüss
  * Author URI: https://objectcache.pro
@@ -640,7 +640,7 @@ class WP_Object_Cache {
             'timeout' => 1,
             'read_timeout' => 1,
             'retry_interval' => null,
-            'persistant' => false,
+            'persistent' => false,
         ];
 
         $settings = [
@@ -906,7 +906,7 @@ class WP_Object_Cache {
      * @return void
      */
     protected function connect_using_credis( $parameters ) {
-        _doing_it_wrong(__FUNCTION__, 'Credis support will be removed in future versions.', '2.0.26');
+        _doing_it_wrong( __FUNCTION__ , 'Credis support will be removed in future versions.' , '2.0.26' );
 
         $client = 'Credis';
 
@@ -1045,7 +1045,7 @@ class WP_Object_Cache {
      * @return void
      */
     protected function connect_using_hhvm( $parameters ) {
-        _doing_it_wrong(__FUNCTION__, 'HHVM support will be removed in future versions.', '2.0.26');
+        _doing_it_wrong( __FUNCTION__ , 'HHVM support will be removed in future versions.' , '2.0.26' );
 
         $this->redis = new Redis();
 
@@ -1104,7 +1104,7 @@ class WP_Object_Cache {
         if ( defined( 'WP_REDIS_CLUSTER' ) ) {
             $connectionID = current( $this->build_cluster_connection_array() );
 
-            $info = ($this->determine_client() === 'predis')
+            $info = $this->determine_client() === 'predis'
                 ? $this->redis->getClientFor( $connectionID )->info()
                 : $this->redis->info( $connectionID );
         } else {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -568,7 +568,6 @@ class WP_Object_Cache {
                 $this->diagnostics[ 'ping' ] = ($client === 'predis')
                     ? $this->redis->getClientFor( $connectionID )->ping()
                     : $this->redis->ping( $connectionID );
-
             } else {
                 $this->diagnostics[ 'ping' ] = $this->redis->ping();
             }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2769,8 +2769,8 @@ LUA;
             $connection_string = parse_url( $server );
             $cluster[ $key ] = sprintf(
                 "%s:%s",
-                $connection_string[ 'host' ],
-                $connection_string[ 'port' ]
+                $connection_string['host'],
+                $connection_string['port']
             );
         }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2988,7 +2988,7 @@ LUA;
      *
      * @return  array
      */
-    public function build_cluster_connection_array() {
+    protected function build_cluster_connection_array() {
         $cluster = array_values( WP_REDIS_CLUSTER );
 
         foreach ( $cluster as $key => $server ) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -966,51 +966,9 @@ class WP_Object_Cache {
             $this->redis = $sentinel->getCluster( WP_REDIS_SENTINEL );
             $args['servers'] = WP_REDIS_SERVERS;
         } elseif ( defined( 'WP_REDIS_CLUSTER' ) || defined( 'WP_REDIS_SERVERS' ) ) {
-            $parameters['db'] = $parameters['database'];
-
-            $is_cluster = defined( 'WP_REDIS_CLUSTER' );
-            $clients = $is_cluster ? WP_REDIS_CLUSTER : WP_REDIS_SERVERS;
-
-            foreach ( $clients as $index => $connection_string ) {
-                // phpcs:ignore WordPress.WP.AlternativeFunctions.parse_url_parse_url
-                $url_components = parse_url( $connection_string );
-
-                if ( isset( $url_components['query'] ) ) {
-                    parse_str( $url_components['query'], $add_params );
-                }
-
-                if ( ! $is_cluster && isset( $add_params['alias'] ) ) {
-                    $add_params['master'] = 'master' === $add_params['alias'];
-                }
-
-                $add_params['host'] = $url_components['host'];
-                $add_params['port'] = $url_components['port'];
-
-                if ( ! isset( $add_params['alias'] ) ) {
-                    $add_params['alias'] = "redis-$index";
-                }
-
-                $clients[ $index ] = array_merge( $parameters, $add_params );
-                
-                unset($add_params);
-            }
-
-            $this->redis = new Credis_Cluster( $clients );
-
-            foreach ( $clients as $index => $_client ) {
-                $connection_string = "{$_client['scheme']}://{$_client['host']}:{$_client['port']}";
-                unset( $_client['scheme'], $_client['host'], $_client['port'] );
-
-                $params = array_filter( $_client );
-
-                if ( $params ) {
-                    $connection_string .= '?' . http_build_query( $params, null, '&' );
-                }
-
-                $clients[ $index ] = $connection_string;
-            }
-
-            $args['servers'] = $clients;
+            throw new Exception(
+                'Clusters not fully supported by bundled Credis library. Please review your Redis Cache configuration.'
+            );
         } else {
             $args = [
                 'host' => $parameters['scheme'] === 'unix' ? $parameters['path'] : $parameters['host'],

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -690,7 +690,7 @@ class WP_Object_Cache {
                 'cluster' => $this->build_cluster_connection_array(),
                 'timeout' => $parameters['timeout'],
                 'read_timeout' => $parameters['read_timeout'],
-                'persistant' => $parameters['persistant'],
+                'persistent' => $parameters['persistent'],
             ];
 
             if ( isset( $parameters['password'] ) && version_compare( $version, '4.3.0', '>=' ) ) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -991,6 +991,8 @@ class WP_Object_Cache {
                 }
 
                 $clients[ $index ] = array_merge( $parameters, $add_params );
+                
+                unset($add_params);
             }
 
             $this->redis = new Credis_Cluster( $clients );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -563,7 +563,14 @@ class WP_Object_Cache {
             }
 
             if ( defined( 'WP_REDIS_CLUSTER' ) ) {
-                $connectionID = current( array_values( WP_REDIS_CLUSTER ) );
+                $currentServer = current( array_values( WP_REDIS_CLUSTER ) );
+                $scheme = sprintf( '%s://' , current( explode( '://' , $currentServer ) ) );
+
+                $connectionID = current(
+                    explode( '?' ,
+                        str_replace( $scheme , '' , $currentServer )
+                    )
+                );
 
                 $this->diagnostics[ 'ping' ] = ($client === 'predis')
                     ? $this->redis->getClientFor( $connectionID )->ping()
@@ -1090,7 +1097,16 @@ class WP_Object_Cache {
         }
 
         if ( defined( 'WP_REDIS_CLUSTER' ) ) {
-            $info = $this->redis->info( current( array_values( WP_REDIS_CLUSTER ) ) );
+            $currentServer = current( array_values( WP_REDIS_CLUSTER ) );
+            $scheme = sprintf( '%s://' , current( explode( '://' , $currentServer ) ) );
+
+            $connectionID = current(
+                explode( '?' ,
+                    str_replace( $scheme , '' , $currentServer )
+                )
+            );
+
+            $info = $this->redis->getClientFor( $connectionID )->info();
         } else {
             $info = $this->redis->info();
         }


### PR DESCRIPTION
> **Warning**
> 1. This PR does no guarantee that the GH tests will pass (not yet).
> 2. I can't say I was able to test all the available scheme locally, but I know it works for `tcp`.


This PR is related to using `predis`/`phpredis` with `clusters`.

Related issues : 
- https://github.com/rhubarbgroup/redis-cache/issues/331
- https://wordpress.org/support/topic/ping-issue-on-cluster-connection/

<details>
<summary>Predis Diagnostics</summary>

```
Status: Connected
Client: Predis (v1.1.10)
Drop-in: Valid
Disabled: No
Ping: PONG
Errors: []
PhpRedis: 5.3.7
Relay: Not loaded
Predis: 1.1.10
Credis: Not loaded
PHP Version: 8.1.7
Plugin Version: 2.0.26
Redis Version: 6.2.0
Multisite: No
Metrics: Enabled
Metrics recorded: 46
Filesystem: Working
Global Prefix: "wp_"
Blog Prefix: "wp_"
WP_REDIS_CLIENT: "predis"
WP_REDIS_SCHEME: "tls"
WP_REDIS_DATABASE: 0
WP_REDIS_TIMEOUT: 1
WP_REDIS_READ_TIMEOUT: 1
WP_REDIS_CLUSTER: ["tls://redis-cluster-container.com:7000?alias=node-01","tls://redis-cluster-container.com:7001?alias=node-02","tls://redis-cluster-container.com:7002?alias=node-03","tls://redis-cluster-container.com:7003?alias=node-04","tls://redis-cluster-container.com:7004?alias=node-05","tls://redis-cluster-container.com:7005?alias=node-06"]
Global Groups: [
    "blog-details",
    "blog-id-cache",
    "blog-lookup",
    "global-posts",
    "networks",
    "rss",
    "sites",
    "site-details",
    "site-lookup",
    "site-options",
    "site-transient",
    "users",
    "useremail",
    "userlogins",
    "usermeta",
    "user_meta",
    "userslugs",
    "redis-cache",
    "blog_meta"
]
Ignored Groups: [
    "counts",
    "plugins",
    "themes"
]
Unflushable Groups: []
Groups Types: {
    "blog-details": "global",
    "blog-id-cache": "global",
    "blog-lookup": "global",
    "global-posts": "global",
    "networks": "global",
    "rss": "global",
    "sites": "global",
    "site-details": "global",
    "site-lookup": "global",
    "site-options": "global",
    "site-transient": "global",
    "users": "global",
    "useremail": "global",
    "userlogins": "global",
    "usermeta": "global",
    "user_meta": "global",
    "userslugs": "global",
    "redis-cache": "global",
    "counts": "ignored",
    "plugins": "ignored",
    "themes": "ignored",
    "blog_meta": "global"
}
Drop-ins: [
    "Query Monitor Database Class (Drop-in) v3.9.0 by John Blackbourn",
    "Redis Object Cache Drop-In v2.0.26 by Till Krüss"
]
```

</details>


<details>
<summary>PHPRedis Diagnostics</summary>

```
Status: Connected
Client: PhpRedis (v5.3.7)
Drop-in: Valid
Disabled: No
Ping: 1
Errors: []
PhpRedis: 5.3.7
Relay: Not loaded
Predis: Not loaded
Credis: Not loaded
PHP Version: 8.1.7
Plugin Version: 2.0.26
Redis Version: 6.2.0
Multisite: No
Metrics: Enabled
Metrics recorded: 18
Filesystem: Working
Global Prefix: "wp_"
Blog Prefix: "wp_"
WP_REDIS_SCHEME: "tls"
WP_REDIS_DATABASE: 0
WP_REDIS_TIMEOUT: 1
WP_REDIS_READ_TIMEOUT: 1
WP_REDIS_CLUSTER: ["tls://redis-cluster-container.com:7000?alias=node-01","tls://redis-cluster-container.com:7001?alias=node-02","tls://redis-cluster-container.com:7002?alias=node-03","tls://redis-cluster-container.com:7003?alias=node-04","tls://redis-cluster-container.com:7004?alias=node-05","tls://redis-cluster-container.com:7005?alias=node-06"]
Global Groups: [
    "blog-details",
    "blog-id-cache",
    "blog-lookup",
    "global-posts",
    "networks",
    "rss",
    "sites",
    "site-details",
    "site-lookup",
    "site-options",
    "site-transient",
    "users",
    "useremail",
    "userlogins",
    "usermeta",
    "user_meta",
    "userslugs",
    "redis-cache",
    "blog_meta"
]
Ignored Groups: [
    "counts",
    "plugins",
    "themes"
]
Unflushable Groups: []
Groups Types: {
    "blog-details": "global",
    "blog-id-cache": "global",
    "blog-lookup": "global",
    "global-posts": "global",
    "networks": "global",
    "rss": "global",
    "sites": "global",
    "site-details": "global",
    "site-lookup": "global",
    "site-options": "global",
    "site-transient": "global",
    "users": "global",
    "useremail": "global",
    "userlogins": "global",
    "usermeta": "global",
    "user_meta": "global",
    "userslugs": "global",
    "redis-cache": "global",
    "counts": "ignored",
    "plugins": "ignored",
    "themes": "ignored",
    "blog_meta": "global"
}
Drop-ins: [
    "Query Monitor Database Class (Drop-in) v3.9.0 by John Blackbourn",
    "Redis Object Cache Drop-In v2.0.26 by Till Krüss"
]
```

</details>

- When using PHPRedis, we need to cleanup the seeds so they are `seeds must be specified in host:port without scheme` per https://github.com/phpredis/phpredis/issues/1607#issuecomment-653578201

