### PR TITLE
Replication bug

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -817,7 +817,7 @@ class WP_Object_Cache {
         } elseif ( defined( 'WP_REDIS_SERVERS' ) ) {
             $servers = WP_REDIS_SERVERS;
             $parameters['servers'] = $servers;
-            $options['replication'] = true;
+            $options['replication'] = 'predis';
         } elseif ( defined( 'WP_REDIS_CLUSTER' ) ) {
             $servers = $this->build_cluster_connection_array();
             $parameters['cluster'] = $servers;


### PR DESCRIPTION
true not work..
true => 'predis'

AND 
wp-config.php
WP_REDIS_SERVERS
parameter : alias=master does not work. role=master & role=replica
ex) define( 'WP_REDIS_SERVERS',['tcp://127.0.0.1:6379?database=0&role=master','tcp://127.0.0.1:6380?database=0&role=replica']);