### PR TITLE
Fix array_map error with empty result of exec method

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1210,9 +1210,15 @@ class WP_Object_Cache {
 
             $method = $this->is_predis() ? 'execute' : 'exec';
 
+            $results = $tx->{$method}();
+
+            if ( ! is_array( $results ) ) {
+                $results = [];
+            }
+
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $tx->{$method}() );
+            }, $results );
 
             $results = array_combine( $keys, $results );
 
@@ -1455,9 +1461,15 @@ class WP_Object_Cache {
 
             $method = $this->is_predis() ? 'execute' : 'exec';
 
+            $results = $tx->{$method}();
+
+            if ( ! is_array( $results ) ) {
+                $results = [];
+            }
+
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $tx->{$method}() );
+            }, $results );
 
             $execute_time = microtime( true ) - $start_time;
         } catch ( Exception $exception ) {
@@ -2104,9 +2116,15 @@ LUA;
         try {
             $method = $this->is_predis() ? 'execute' : 'exec';
 
+            $results = $tx->{$method}();
+
+            if ( ! is_array( $results ) ) {
+                $results = [];
+            }
+
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $tx->{$method}() );
+            }, $results );
 
             $results = array_combine( $keys, $results );
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1210,15 +1210,9 @@ class WP_Object_Cache {
 
             $method = $this->is_predis() ? 'execute' : 'exec';
 
-            $results = $tx->{$method}();
-
-            if ( ! is_array( $results ) ) {
-                $results = [];
-            }
-
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $results );
+            }, $tx->{$method}() ?? [] );
 
             $results = array_combine( $keys, $results );
 
@@ -1461,15 +1455,9 @@ class WP_Object_Cache {
 
             $method = $this->is_predis() ? 'execute' : 'exec';
 
-            $results = $tx->{$method}();
-
-            if ( ! is_array( $results ) ) {
-                $results = [];
-            }
-
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $results );
+            }, $tx->{$method}() ?? [] );
 
             $execute_time = microtime( true ) - $start_time;
         } catch ( Exception $exception ) {
@@ -2116,15 +2104,9 @@ LUA;
         try {
             $method = $this->is_predis() ? 'execute' : 'exec';
 
-            $results = $tx->{$method}();
-
-            if ( ! is_array( $results ) ) {
-                $results = [];
-            }
-
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
-            }, $results );
+            }, $tx->{$method}() ?? [] );
 
             $results = array_combine( $keys, $results );
 


### PR DESCRIPTION
Received an error when calling the `Redis->pipeline->exec` method, which may not return an array, resulting in the following log:

```
PHP Warning:  array_map(): Expected parameter 2 to be an array, bool given in /home/user/public_html/wp-content/object-cache.php on line 1212
PHP Warning:  array_combine() expects parameter 2 to be array, null given in /home/user/public_html/wp-content/object-cache.php on line 1214
PHP Warning:  Invalid argument supplied for foreach() in /home/user/public_html/wp-content/object-cache.php on line 1216
```

Added a result check to make sure we got an array to pass to the array_map function.