### PR TITLE
Throw exception when Redis pipeline returns unexpected results

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1215,6 +1215,10 @@ class WP_Object_Cache {
                 return (bool) $this->parse_redis_response( $response );
             }, $tx->{$method}() ?? [] );
 
+            if ( count( $results ) < count( $keys ) ) {
+                throw new Exception('Redis pipeline returned unexpected results');
+            }
+
             $results = array_combine( $keys, $results );
 
             foreach ( $results as $key => $result ) {
@@ -1459,6 +1463,10 @@ class WP_Object_Cache {
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
             }, $tx->{$method}() ?? [] );
+
+            if ( count( $results ) < count( $keys ) ) {
+                throw new Exception('Redis pipeline returned unexpected results');
+            }
 
             $execute_time = microtime( true ) - $start_time;
         } catch ( Exception $exception ) {
@@ -2108,6 +2116,10 @@ LUA;
             $results = array_map( function ( $response ) {
                 return (bool) $this->parse_redis_response( $response );
             }, $tx->{$method}() ?? [] );
+
+            if ( count( $results ) < count( $keys ) ) {
+                throw new Exception('Redis pipeline returned unexpected results');
+            }
 
             $results = array_combine( $keys, $results );
 


### PR DESCRIPTION
If the Redis pipeline returns an unexpected result, we will get an error when working with the array_combine function:
"Warning: array_combine(): Both parameters should have an equal number of elements"

To avoid a false positive, it's best to stop interacting with the cache.