### PR TITLE
Add support for the new storage classes in Query Monitor

### DIFF
--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -73,8 +73,13 @@ class QM_Collector extends Base_Collector {
         ];
 
         // These are used by Query Monitor.
-        $this->data['stats']['cache_hits'] = $info->hits;
-        $this->data['stats']['cache_misses'] = $info->misses;
+        if ( $this->data instanceof \QM_Data ) {
+            $this->data->stats['cache_hits'] = $info->hits;
+            $this->data->stats['cache_misses'] = $info->misses;
+        } else {
+            $this->data['stats']['cache_hits'] = $info->hits;
+            $this->data['stats']['cache_misses'] = $info->misses;
+        }
         $this->data['cache_hit_percentage'] = $info->ratio;
     }
 

--- a/includes/class-qm-collector.php
+++ b/includes/class-qm-collector.php
@@ -72,7 +72,9 @@ class QM_Collector extends Base_Collector {
             'unflushable' => $info->groups->unflushable,
         ];
 
-        // These are used by Query Monitor.
+        // These are used by Query Monitor
+        $this->data['cache_hit_percentage'] = $info->ratio;
+
         if ( $this->data instanceof \QM_Data ) {
             $this->data->stats['cache_hits'] = $info->hits;
             $this->data->stats['cache_misses'] = $info->misses;
@@ -80,7 +82,6 @@ class QM_Collector extends Base_Collector {
             $this->data['stats']['cache_hits'] = $info->hits;
             $this->data['stats']['cache_misses'] = $info->misses;
         }
-        $this->data['cache_hit_percentage'] = $info->ratio;
     }
 
     /**


### PR DESCRIPTION
The next release of Query Monitor will [switch to using a `QM_Data` instance for the data storage for each collector](https://github.com/johnbillion/query-monitor/pull/671). The class implements `ArrayAccess` so there's generally no need for third party collectors to change their behaviour, except in the case where they try to write to a second-level element within an array in which case an "Indirect modification of overloaded element of QM_Data_Fallback has no effect" PHP notice will be triggered because it's not possible to write to a property of an overloaded element.

Without this fix the code still works, it just doesn't report the figures for hits and misses. With this fix, all is well again.