### PR TITLE
Fix grokzen/redis-cluster Docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,7 +111,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['7.2', '7.3', '7.4', '8.0', '8.1']
-        redis: ['5.0.12', '6.2.1']
+        redis: ['6.2.8', '7.0.7']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
v5 was dropped

https://github.com/Grokzen/docker-redis-cluster/commit/d597529abb5d9e8b02721c7a2a690f7100fd67e8
https://hub.docker.com/r/grokzen/redis-cluster/tags
