### PR TITLE
Add Relay extension check for OCP compatibility check

### DIFF
--- a/includes/ui/settings.php
+++ b/includes/ui/settings.php
@@ -101,8 +101,9 @@ defined( '\\ABSPATH' ) || exit;
                 <?php $is_php7 = version_compare( phpversion(), '7.2', '>=' ); ?>
                 <?php $is_phpredis311 = version_compare( phpversion( 'redis' ), '3.1.1', '>=' ); ?>
                 <?php $phpredis_installed = (bool) phpversion( 'redis' ); ?>
+                <?php $relay_installed = (bool) phpversion( 'relay' ); ?>
 
-                <?php if ( $is_php7 && $is_phpredis311 ) : ?>
+                <?php if ( $is_php7 && ( $is_phpredis311 || $relay_installed ) ) : ?>
 
                     <p class="compatibility">
                         <span class="dashicons dashicons-yes"></span>


### PR DESCRIPTION
The [Ymir](https://ymirapp.com) runtime doesn't use the PhpRedis extension and only [Relay](https://relay.so). The upsell for OCP says that the environment isn't compatible because PhpRedis extension is missing, but that's not the case.