### PR TITLE
remove visible passwords from overview and diagnostics when passing passwords via connection string

### DIFF
--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -117,6 +117,10 @@ if ( defined( 'WP_REDIS_PASSWORD' ) ) {
     }
 }
 
+if ( defined( 'WP_REDIS_SERVERS' ) ) {
+    $info['WP_REDIS_SERVERS'] = preg_replace('/password=(.+[a-zA-Z])(?=&{0,1})/um', 'password=********', $info['WP_REDIS_SERVERS']);
+}
+
 if ( $dropin && ! $disabled ) {
     $info['Global Groups'] = wp_json_encode(
         array_values( $wp_object_cache->global_groups ?? [] ),

--- a/includes/ui/tabs/overview.php
+++ b/includes/ui/tabs/overview.php
@@ -176,7 +176,7 @@ $diagnostics = $roc->get_diagnostics();
             <td>
                 <ul>
                     <?php foreach ( $diagnostics['servers'] as $node ) : ?>
-                        <li><code><?php echo esc_html( $node ); ?></code></li>
+                        <li><code><?php echo esc_html( preg_replace('/password=(.+[a-zA-Z])(?=&{0,1})/um', 'password=********', $node) ); ?></code></li>
                     <?php endforeach; ?>
                 </ul>
             </td>


### PR DESCRIPTION
In my situation, I am using Redis with Sentinel option enabled in Kubernetes. All sentinels (and Redis) are available at an internal service of "redis" and it is only necessary to define the single instance. However, when using Redis Sentinel, where the sentinel requires a password, the password may be passed via the configuration like this:

```
define( 'WP_REDIS_SERVERS', [
  'redis:26379/?password=sentinel-password'
] );
```

This information is then visible on the overview and diagnostics screen. This PR redacts the information before display. I did not create an associated "Issue" however.