### PR TITLE
Update object-cache.php

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -890,6 +890,10 @@ class WP_Object_Cache {
                 }
             }
         }
+ 
+        if ( isset( $parameters['password'] ) ) {
+            $parameters['username'] = WP_REDIS_USERNAME;
+        }
 
         $this->redis = new Predis\Client( $servers ?: $parameters, $options );
         $this->redis->connect();

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -891,7 +891,7 @@ class WP_Object_Cache {
             }
         }
  
-        if ( isset( $parameters['password'] ) ) {
+        if ( isset( $parameters['password'] ) && defined( 'WP_REDIS_USERNAME' ) ) {
             $parameters['username'] = WP_REDIS_USERNAME;
         }
 


### PR DESCRIPTION
you may want to add WP_REDIS_USERNAME or keep WP_REDIS_PASSWORD as array.

also, you could do basically eliminate this loop:

        foreach ( [ 'WP_REDIS_SERVERS', 'WP_REDIS_SHARDS', 'WP_REDIS_CLUSTER' ] as $constant ) {

and the whole thing will work without my changes.