### PR TITLE
Add WP_REDIS_SSL setting, pass to predis and phpredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The plugin comes with vast set of configuration options.
 | `WP_REDIS_DISABLE_METRICS`           | `false`     | Disables metrics collection and display |
 | `WP_REDIS_DISABLE_BANNERS`           | `false`     | Disables promotional banners |
 | `WP_REDIS_DISABLE_DROPIN_AUTOUPDATE` | `false`     | Disables the drop-in auto-update |
-| `WP_REDIS_TLS`                       |             | TLS connection options for `tls` or `rediss` scheme |
+| `WP_REDIS_SSL_CONTEXT`               | `[]`        | TLS connection options for `tls` or `rediss` scheme |
 
 </details>
 
@@ -98,10 +98,10 @@ define( 'WP_REDIS_HOST', 'master.ncit.ameaqx.use1.cache.amazonaws.com' );
 define( 'WP_REDIS_PORT', 6379 );
 ```
 
-Additional stream connection options for `phpredis` and `predis` connections can be defined using `WP_REDIS_TLS`
+Additional stream connection options for `phpredis`, `relay`, and `predis` connections can be defined using `WP_REDIS_SSL_CONTEXT`
 
 ```php
-define( 'WP_REDIS_TLS', [
+define( 'WP_REDIS_SSL_CONTEXT', [
     'verify_host' => false,
     'verify_host_name' => false
 ]);

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The plugin comes with vast set of configuration options.
 | `WP_REDIS_DISABLE_METRICS`           | `false`     | Disables metrics collection and display |
 | `WP_REDIS_DISABLE_BANNERS`           | `false`     | Disables promotional banners |
 | `WP_REDIS_DISABLE_DROPIN_AUTOUPDATE` | `false`     | Disables the drop-in auto-update |
+| `WP_REDIS_TLS`                       |             | TLS connection options for `tls` or `rediss` scheme |
 
 </details>
 
@@ -95,6 +96,15 @@ define( 'WP_REDIS_PATH', '/var/run/redis.sock' );
 define( 'WP_REDIS_SCHEME', 'tls' );
 define( 'WP_REDIS_HOST', 'master.ncit.ameaqx.use1.cache.amazonaws.com' );
 define( 'WP_REDIS_PORT', 6379 );
+```
+
+Additional stream connection options for `phpredis` and `predis` connections can be defined using `WP_REDIS_TLS`
+
+```php
+define( 'WP_REDIS_TLS', [
+    'verify_host' => false,
+    'verify_host_name' => false
+]);
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Additional TLS/SSL stream connection options for connections can be defined usin
 ```php
 define( 'WP_REDIS_SSL_CONTEXT', [
     'verify_host' => false,
-    'verify_host_name' => false
+    'verify_host_name' => false,
 ]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ define( 'WP_REDIS_HOST', 'master.ncit.ameaqx.use1.cache.amazonaws.com' );
 define( 'WP_REDIS_PORT', 6379 );
 ```
 
-Additional stream connection options for `phpredis`, `relay`, and `predis` connections can be defined using `WP_REDIS_SSL_CONTEXT`
+Additional TLS/SSL stream connection options for connections can be defined using `WP_REDIS_SSL_CONTEXT`:
 
 ```php
 define( 'WP_REDIS_SSL_CONTEXT', [

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -69,6 +69,7 @@ $constants = [
     'WP_REDIS_DISABLED',
     'WP_REDIS_CLIENT',
     'WP_REDIS_SCHEME',
+    'WP_REDIS_SSL_CONTEXT',
     'WP_REDIS_PATH',
     'WP_REDIS_HOST',
     'WP_REDIS_PORT',
@@ -91,7 +92,6 @@ $constants = [
     'WP_REDIS_IGNORED_GROUPS',
     'WP_REDIS_UNFLUSHABLE_GROUPS',
     'WP_REDIS_SELECTIVE_FLUSH',
-    'WP_REDIS_SSL_CONTEXT'
 ];
 
 foreach ( $constants as $constant ) {

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -91,6 +91,7 @@ $constants = [
     'WP_REDIS_IGNORED_GROUPS',
     'WP_REDIS_UNFLUSHABLE_GROUPS',
     'WP_REDIS_SELECTIVE_FLUSH',
+    'WP_REDIS_TLS'
 ];
 
 foreach ( $constants as $constant ) {

--- a/includes/diagnostics.php
+++ b/includes/diagnostics.php
@@ -91,7 +91,7 @@ $constants = [
     'WP_REDIS_IGNORED_GROUPS',
     'WP_REDIS_UNFLUSHABLE_GROUPS',
     'WP_REDIS_SELECTIVE_FLUSH',
-    'WP_REDIS_TLS'
+    'WP_REDIS_SSL_CONTEXT'
 ];
 
 foreach ( $constants as $constant ) {

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -640,7 +640,7 @@ class WP_Object_Cache {
             'database',
             'timeout',
             'read_timeout',
-            'retry_interval'
+            'retry_interval',
         ];
 
         foreach ( $settings as $setting ) {
@@ -712,8 +712,8 @@ class WP_Object_Cache {
                     $parameters['scheme'],
                     str_replace( 'tls://', '', $parameters['host'] )
                 );
-                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_TLS' ) && !empty(WP_REDIS_TLS) ) {
-                    $args['others']['stream'] = WP_REDIS_TLS;
+                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+                    $args['others']['stream'] = WP_REDIS_SSL_CONTEXT;
                 }
             }
 
@@ -775,20 +775,23 @@ class WP_Object_Cache {
                 'retry_interval' => (int) $parameters['retry_interval'],
             ];
 
+            $args['read_timeout'] = $parameters['read_timeout'];
+
             if ( strcasecmp( 'tls', $parameters['scheme'] ) === 0 ) {
                 $args['host'] = sprintf(
                     '%s://%s',
                     $parameters['scheme'],
                     str_replace( 'tls://', '', $parameters['host'] )
                 );
+                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+                    $args['others']['stream'] = WP_REDIS_SSL_CONTEXT;
+                }
             }
 
             if ( strcasecmp( 'unix', $parameters['scheme'] ) === 0 ) {
                 $args['host'] = $parameters['path'];
                 $args['port'] = -1;
             }
-
-            $args['read_timeout'] = $parameters['read_timeout'];
 
             call_user_func_array( [ $this->redis, 'connect' ], array_values( $args ) );
 
@@ -894,8 +897,8 @@ class WP_Object_Cache {
             }
         }
 
-        if ( defined( 'WP_REDIS_TLS' ) && !empty(WP_REDIS_TLS) ) {
-            $parameters['ssl'] = WP_REDIS_TLS;
+        if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+            $parameters['ssl'] = WP_REDIS_SSL_CONTEXT;
         }
 
         $this->redis = new Predis\Client( $servers ?: $parameters, $options );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -712,7 +712,8 @@ class WP_Object_Cache {
                     $parameters['scheme'],
                     str_replace( 'tls://', '', $parameters['host'] )
                 );
-                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+
+                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
                     $args['others']['stream'] = WP_REDIS_SSL_CONTEXT;
                 }
             }
@@ -783,7 +784,8 @@ class WP_Object_Cache {
                     $parameters['scheme'],
                     str_replace( 'tls://', '', $parameters['host'] )
                 );
-                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+
+                if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
                     $args['others']['stream'] = WP_REDIS_SSL_CONTEXT;
                 }
             }
@@ -897,7 +899,7 @@ class WP_Object_Cache {
             }
         }
 
-        if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && !empty(WP_REDIS_SSL_CONTEXT) ) {
+        if ( defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
             $parameters['ssl'] = WP_REDIS_SSL_CONTEXT;
         }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -641,6 +641,7 @@ class WP_Object_Cache {
             'timeout',
             'read_timeout',
             'retry_interval',
+            'ssl'
         ];
 
         foreach ( $settings as $setting ) {
@@ -708,6 +709,7 @@ class WP_Object_Cache {
                     $parameters['scheme'],
                     str_replace( 'tls://', '', $parameters['host'] )
                 );
+                $args['ssl'] = $parameters['ssl'];
             }
 
             if ( strcasecmp( 'unix', $parameters['scheme'] ) === 0 ) {


### PR DESCRIPTION
Simple fix to allow a WP_REDIS_SSL setting to pass SSL connection arguments in the case of a TLS service (such as Heroku) that needs additional SSL parameters.

`connect_using_phpredis()` sets an 'ssl' key on it's connection arguments derived from it via `$parameters['ssl']`, `connect_using_predis()` directly uses the `$parameters['ssl']` value.

e.g.
```php
	define('WP_REDIS_SSL', [
		'verify_host' => false,
		'verify_peer' => false,
		'verify_peer_name' => false,
	]);
```