### PR TITLE
Use correct placeholders for admin bar title

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -729,8 +729,8 @@ class Plugin {
             );
 
             $meta_title = sprintf(
-                // translators: %1$d = hit ratio. %2$d = hits. %3$d = misses. %4$s = human-readable size of cache.
-                __( 'Hit Ratio: %1$d%%, Hits %2$d, Misses: %3$d, Size: %4$s', 'redis-cache' ),
+                // translators: 1: Hit ratio, 2: Hits, 3: Misses. 4: Human-readable size of cache.
+                __( 'Hit Ratio: %1$s%%, Hits %2$s, Misses: %3$s, Size: %4$s', 'redis-cache' ),
                 $info->ratio,
                 $hits,
                 $misses,


### PR DESCRIPTION
Using `%d` for strings makes the title having only rounded numbers:

<img width="403" alt="Bildschirm­foto 2023-04-18 um 16 04 42" src="https://user-images.githubusercontent.com/617637/232803405-331cd11b-819b-47f3-8a86-64d4c95ac464.png">

This also simplifies the translators comment per https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#descriptions
