### PR TITLE
Format statistcs according to current locale

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -715,8 +715,8 @@ class Plugin {
             global $wp_object_cache;
 
             $info = $wp_object_cache->info();
-            $hits = number_format( $info->hits );
-            $misses = number_format( $info->misses );
+            $hits = number_format_i18n( $info->hits );
+            $misses = number_format_i18n( $info->misses );
             $size = size_format( $info->bytes );
 
             $value = sprintf(

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2438,7 +2438,7 @@ LUA;
         <?php echo (int) $this->cache_misses; ?>
         <br />
         <strong>Cache Size:</strong>
-        <?php echo number_format( strlen( serialize( $this->cache ) ) / 1024, 2 ); ?> KB
+        <?php echo number_format_i18n( strlen( serialize( $this->cache ) ) / 1024, 2 ); ?> KB
     </p>
         <?php
     }


### PR DESCRIPTION
Currently, the statistics are always formatted in the default format, which usually is English. This pull request uses `number_format_i18n` to format the statistics according to the current locale.