### PR TITLE
Update check if plugin was installed by AccelerateWP

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -279,6 +279,10 @@ class Plugin {
             return $plugin_meta;
         }
 
+        if ( defined( 'WP_REDIS_DISABLE_BANNERS' ) && WP_REDIS_DISABLE_BANNERS ) {
+            return $plugin_meta;
+        }
+
         $plugin_meta[] = sprintf(
             '<a href="%1$s"><span class="dashicons dashicons-star-filled" aria-hidden="true" style="font-size: 14px; line-height: 1.3"></span>%2$s</a>',
             $this->link_to_ocp('meta-row'),
@@ -300,10 +304,8 @@ class Plugin {
         $ref = 'oss';
 
         if (
-            ( defined( 'WP_ROCKET_WEB_MAIN' ) && strpos( (string) WP_ROCKET_WEB_MAIN, 'cloudlinux.com' ) ) ||
-            ( defined( 'WP_ROCKET_UPDATE_PATH' ) && strpos( (string) WP_ROCKET_UPDATE_PATH, 'cloudlinux' ) ) ||
-            ( defined( 'CL_SMART_ADVICE_VERSION' ) && ! empty( CL_SMART_ADVICE_VERSION ) ) ||
-            is_readable( '/opt/alt/php-xray/' )
+            ( defined( 'WP_REDIS_SCHEME' ) && 'unix' === WP_REDIS_SCHEME ) &&
+            ( defined( 'WP_REDIS_PATH' ) && false !== strpos( (string) WP_REDIS_PATH, '.clwpos/redis.sock' ) )
         ) {
             $ref = 'oss-cl';
         }

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -302,8 +302,11 @@ class Plugin {
     public function link_to_ocp($medium, $as_html = true)
     {
         $ref = 'oss';
+        
+        $scheme = defined( 'WP_REDIS_SCHEME' ) ? WP_REDIS_SCHEME : null;
+        $path = defined( 'WP_REDIS_PATH' ) ? WP_REDIS_PATH : null;
 
-        if ( defined( 'WP_REDIS_PATH' ) && strpos( (string) WP_REDIS_PATH, '.clwpos/redis.sock' ) !== false ) {
+        if ( $scheme === 'unix' && strpos( (string) $path, '.clwpos/redis.sock' ) !== false ) {
             $ref = 'oss-cl';
         }
 

--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -303,10 +303,7 @@ class Plugin {
     {
         $ref = 'oss';
 
-        if (
-            ( defined( 'WP_REDIS_SCHEME' ) && 'unix' === WP_REDIS_SCHEME ) &&
-            ( defined( 'WP_REDIS_PATH' ) && false !== strpos( (string) WP_REDIS_PATH, '.clwpos/redis.sock' ) )
-        ) {
+        if ( defined( 'WP_REDIS_PATH' ) && strpos( (string) WP_REDIS_PATH, '.clwpos/redis.sock' ) !== false ) {
             $ref = 'oss-cl';
         }
 

--- a/includes/ui/settings.php
+++ b/includes/ui/settings.php
@@ -65,7 +65,7 @@ defined( '\\ABSPATH' ) || exit;
         </div>
 
         <div class="sidebar-column">
-
+            <?php if ( ! defined( 'WP_REDIS_DISABLE_BANNERS' ) || ! WP_REDIS_DISABLE_BANNERS ): ?>
             <h6>
                 <?php esc_html_e( 'Resources', 'redis-cache' ); ?>
             </h6>
@@ -155,7 +155,7 @@ defined( '\\ABSPATH' ) || exit;
                 <?php endif; ?>
 
             </div>
-
+            <?php endif; ?>
         </div>
 
     </div>


### PR DESCRIPTION
This PR changes the way plugin detects if it was installed by AccelerateWP. It relies on specific value of constants `WP_REDIS_PATH` and `WP_REDIS_SCHEME`.

It also makes settings screen and links in the plugins list respect the `WP_REDIS_DISABLE_BANNERS` constant.