### PR TITLE
Update banner visibility rules for AccelerateWP installs.

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -279,9 +279,13 @@ class Plugin {
             return $plugin_meta;
         }
 
+        if ( defined( 'WP_REDIS_DISABLE_BANNERS' ) && WP_REDIS_DISABLE_BANNERS && Plugin::is_acceleratewp_install() ) {
+            return $plugin_meta;
+        }
+
         $plugin_meta[] = sprintf(
             '<a href="%1$s"><span class="dashicons dashicons-star-filled" aria-hidden="true" style="font-size: 14px; line-height: 1.3"></span>%2$s</a>',
-            $this->link_to_ocp('meta-row'),
+            $this->link_to_ocp( 'meta-row' ),
             esc_html_x( 'Upgrade to Pro', 'verb', 'redis-cache' )
         );
 
@@ -298,11 +302,7 @@ class Plugin {
     public function link_to_ocp($medium, $as_html = true)
     {
         $ref = 'oss';
-
-        $scheme = defined( 'WP_REDIS_SCHEME' ) ? WP_REDIS_SCHEME : null;
-        $path = defined( 'WP_REDIS_PATH' ) ? WP_REDIS_PATH : null;
-
-        if ( $scheme === 'unix' && strpos( (string) $path, '.clwpos/redis.sock' ) !== false ) {
+        if ( self::is_acceleratewp_install() ) {
             $ref = 'oss-cl';
         }
 
@@ -1558,5 +1558,26 @@ HTML;
      */
     public function current_user_can_manage_redis() {
         return current_user_can( $this->manage_redis_capability() );
+    }
+
+    /**
+     * Checks if the plugin was installed by AccelerateWP from CloudLinux.
+     *
+     * @since 2.4.2
+     *
+     * @return bool True if the plugin was installed by AccelerateWP from CloudLinux, false otherwise.
+     */
+    public static function is_acceleratewp_install() {
+        $scheme = defined( 'WP_REDIS_SCHEME' ) ? WP_REDIS_SCHEME : null;
+        if ( 'unix' !== $scheme ) {
+            return false;
+        }
+
+        $path = defined( 'WP_REDIS_PATH' ) ? WP_REDIS_PATH : null;
+        if ( false === strpos( (string) $path, '.clwpos/redis.sock' ) ) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/includes/ui/settings.php
+++ b/includes/ui/settings.php
@@ -7,6 +7,7 @@
 
 namespace Rhubarb\RedisCache\UI;
 
+use Rhubarb\RedisCache\Plugin;
 use Rhubarb\RedisCache\UI;
 
 defined( '\\ABSPATH' ) || exit;
@@ -65,95 +66,97 @@ defined( '\\ABSPATH' ) || exit;
         </div>
 
         <div class="sidebar-column">
-            <h6>
-                <?php esc_html_e( 'Resources', 'redis-cache' ); ?>
-            </h6>
+            <?php if ( ! defined( 'WP_REDIS_DISABLE_BANNERS' ) || ! WP_REDIS_DISABLE_BANNERS || ! Plugin::is_acceleratewp_install() ): ?>
+                <h6>
+                    <?php esc_html_e( 'Resources', 'redis-cache' ); ?>
+                </h6>
 
-            <div class="section-pro">
+                <div class="section-pro">
 
-                <div class="card">
-                    <h2 class="title" style="line-height: 1.4">
-                        <?php
-                            esc_html_e( 'Need more performance and reliability?', 'redis-cache' );
-                        ?><br>
-                        <?php
-                            // translators: %s = Object Cache Pro.
-                            printf( esc_html__( 'Check out %s', 'redis-cache' ), '<span style="color: #dc2626;">Object Cache Pro</span>' );
-                        ?>
-                    </h2>
-                    <p>
-                        <?php wp_kses_post( __( '<strong>A business class object cache backend.</strong> Truly reliable, highly-optimized and fully customizable, with a <u>dedicated engineer</u> when you most need it.', 'redis-cache' ) ); ?>
-                    </p>
-                    <ul>
-                        <li><?php esc_html_e( 'Rewritten for raw performance', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( '100% WordPress API compliant', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Faster serialization and compression', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Easy debugging & logging', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Cache prefetching and analytics', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Fully unit tested (100% code coverage)', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Secure connections with TLS', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Health checks via WordPress & WP CLI', 'redis-cache' ); ?></li>
-                        <li><?php esc_html_e( 'Optimized for WooCommerce, Jetpack & Yoast SEO', 'redis-cache' ); ?></li>
-                    </ul>
-                    <p>
-                        <a class="button button-primary" target="_blank" rel="noopener" href="<?php echo $this->link_to_ocp('settings'); ?>">
-                            <?php esc_html_e( 'Learn more', 'redis-cache' ); ?>
-                        </a>
-                    </p>
+                    <div class="card">
+                        <h2 class="title" style="line-height: 1.4">
+                            <?php
+                                esc_html_e( 'Need more performance and reliability?', 'redis-cache' );
+                            ?><br>
+                            <?php
+                                // translators: %s = Object Cache Pro.
+                                printf( esc_html__( 'Check out %s', 'redis-cache' ), '<span style="color: #dc2626;">Object Cache Pro</span>' );
+                            ?>
+                        </h2>
+                        <p>
+                            <?php wp_kses_post( __( '<strong>A business class object cache backend.</strong> Truly reliable, highly-optimized and fully customizable, with a <u>dedicated engineer</u> when you most need it.', 'redis-cache' ) ); ?>
+                        </p>
+                        <ul>
+                            <li><?php esc_html_e( 'Rewritten for raw performance', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( '100% WordPress API compliant', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Faster serialization and compression', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Easy debugging & logging', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Cache prefetching and analytics', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Fully unit tested (100% code coverage)', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Secure connections with TLS', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Health checks via WordPress & WP CLI', 'redis-cache' ); ?></li>
+                            <li><?php esc_html_e( 'Optimized for WooCommerce, Jetpack & Yoast SEO', 'redis-cache' ); ?></li>
+                        </ul>
+                        <p>
+                            <a class="button button-primary" target="_blank" rel="noopener" href="<?php echo $this->link_to_ocp('settings'); ?>">
+                                <?php esc_html_e( 'Learn more', 'redis-cache' ); ?>
+                            </a>
+                        </p>
+                    </div>
+
+                    <?php $is_php7 = version_compare( phpversion(), '7.2', '>=' ); ?>
+                    <?php $is_phpredis311 = version_compare( phpversion( 'redis' ), '3.1.1', '>=' ); ?>
+                    <?php $phpredis_installed = (bool) phpversion( 'redis' ); ?>
+                    <?php $relay_installed = (bool) phpversion( 'relay' ); ?>
+
+                    <?php if ( $is_php7 && ( $is_phpredis311 || $relay_installed ) ) : ?>
+
+                        <p class="compatibility">
+                            <span class="dashicons dashicons-yes"></span>
+                            <span><?php esc_html_e( 'Your site meets the system requirements for the Pro version.', 'redis-cache' ); ?></span>
+                        </p>
+
+                    <?php else : ?>
+
+                        <p class="compatibility">
+                            <span class="dashicons dashicons-no"></span>
+                            <span><?php echo wp_kses_post( __( 'Your site <i>does not</i> meet the requirements for the Pro version:', 'redis-cache' ) ); ?></span>
+                        </p>
+
+                        <ul>
+                            <?php if ( ! $is_php7 ) : ?>
+                                <li>
+                                    <?php
+                                        printf(
+                                            // translators: %s = PHP Version.
+                                            esc_html__( 'The current version of PHP (%s) is too old. PHP 7.2 or newer is required.', 'redis-cache' ),
+                                            esc_html( phpversion() )
+                                        );
+                                    ?>
+                                </li>
+                            <?php endif; ?>
+
+                            <?php if ( ! $phpredis_installed ) : ?>
+                                <li>
+                                    <?php esc_html_e( 'The PhpRedis extension is not installed.', 'redis-cache' ); ?>
+                                </li>
+                            <?php elseif ( ! $is_phpredis311 ) : ?>
+                                <li>
+                                    <?php
+                                        printf(
+                                            // translators: %s = Version of the PhpRedis extension.
+                                            esc_html__( 'The current version of the PhpRedis extension (%s) is too old. PhpRedis 3.1.1 or newer is required.', 'redis-cache' ),
+                                            esc_html( phpversion( 'redis' ) )
+                                        );
+                                    ?>
+                                </li>
+                            <?php endif; ?>
+                        </ul>
+
+                    <?php endif; ?>
+
                 </div>
-
-                <?php $is_php7 = version_compare( phpversion(), '7.2', '>=' ); ?>
-                <?php $is_phpredis311 = version_compare( phpversion( 'redis' ), '3.1.1', '>=' ); ?>
-                <?php $phpredis_installed = (bool) phpversion( 'redis' ); ?>
-                <?php $relay_installed = (bool) phpversion( 'relay' ); ?>
-
-                <?php if ( $is_php7 && ( $is_phpredis311 || $relay_installed ) ) : ?>
-
-                    <p class="compatibility">
-                        <span class="dashicons dashicons-yes"></span>
-                        <span><?php esc_html_e( 'Your site meets the system requirements for the Pro version.', 'redis-cache' ); ?></span>
-                    </p>
-
-                <?php else : ?>
-
-                    <p class="compatibility">
-                        <span class="dashicons dashicons-no"></span>
-                        <span><?php echo wp_kses_post( __( 'Your site <i>does not</i> meet the requirements for the Pro version:', 'redis-cache' ) ); ?></span>
-                    </p>
-
-                    <ul>
-                        <?php if ( ! $is_php7 ) : ?>
-                            <li>
-                                <?php
-                                    printf(
-                                        // translators: %s = PHP Version.
-                                        esc_html__( 'The current version of PHP (%s) is too old. PHP 7.2 or newer is required.', 'redis-cache' ),
-                                        esc_html( phpversion() )
-                                    );
-                                ?>
-                            </li>
-                        <?php endif; ?>
-
-                        <?php if ( ! $phpredis_installed ) : ?>
-                            <li>
-                                <?php esc_html_e( 'The PhpRedis extension is not installed.', 'redis-cache' ); ?>
-                            </li>
-                        <?php elseif ( ! $is_phpredis311 ) : ?>
-                            <li>
-                                <?php
-                                    printf(
-                                        // translators: %s = Version of the PhpRedis extension.
-                                        esc_html__( 'The current version of the PhpRedis extension (%s) is too old. PhpRedis 3.1.1 or newer is required.', 'redis-cache' ),
-                                        esc_html( phpversion( 'redis' ) )
-                                    );
-                                ?>
-                            </li>
-                        <?php endif; ?>
-                    </ul>
-
-                <?php endif; ?>
-
-            </div>
+            <?php endif; ?>
         </div>
 
     </div>


### PR DESCRIPTION
Changes the logic for displaying Object Cache PRO banners on the settings page and in the plugins' list. Constant `WP_REDIS_DISABLE_BANNERS` now affects visibilities of these banners only for AccelerateWP installs.