### PR TITLE
Handle unexpected result from Redis pipeline quietly.

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1300,7 +1300,7 @@ class WP_Object_Cache {
 
             if ( count( $results ) !== count( $keys ) ) {
                 $tx->discard();
-                return [];
+                return array_fill_keys( $keys, false );
             }
 
             $results = array_combine( $keys, $results );
@@ -1550,7 +1550,7 @@ class WP_Object_Cache {
 
             if ( count( $results ) !== count( $keys ) ) {
                 $tx->discard();
-                return [];
+                return array_fill_keys( $keys, false );
             }
 
             $execute_time = microtime( true ) - $start_time;
@@ -2273,7 +2273,7 @@ LUA;
 
             if ( count( $results ) !== count( $keys ) ) {
                 $tx->discard();
-                return [];
+                return array_fill_keys( $keys, false );
             }
 
             $results = array_combine( $keys, $results );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1299,7 +1299,8 @@ class WP_Object_Cache {
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                throw new Exception( 'Redis pipeline returned unexpected result' );
+                $tx->discard();
+                return [];
             }
 
             $results = array_combine( $keys, $results );
@@ -1548,7 +1549,8 @@ class WP_Object_Cache {
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                throw new Exception( 'Redis pipeline returned unexpected result' );
+                $tx->discard();
+                return [];
             }
 
             $execute_time = microtime( true ) - $start_time;
@@ -2270,7 +2272,8 @@ LUA;
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                throw new Exception( 'Redis pipeline returned unexpected result' );
+                $tx->discard();
+                return [];
             }
 
             $results = array_combine( $keys, $results );


### PR DESCRIPTION
This pull requests changes the behaviour of caching functions that utilize Redis pipeline to execute multiple commands in batch. When the pipeline returns unexpected results, it no longer logs an error, but discard the current transaction and returns an empty array.