### PR TITLE
Check if WP_REDIS_PLUGIN_PATH is defined before defining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Require WordPress 4.6 or newer
 - Load text-domain on-demand
 - Call `redis_object_cache_error` action before `wp_die()`
+- Fixed `WP_REDIS_PLUGIN_PATH` already defined warning
 
 ## 2.4.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Require WordPress 4.6 or newer
 - Load text-domain on-demand
 - Call `redis_object_cache_error` action before `wp_die()`
-- Fixed `WP_REDIS_PLUGIN_PATH` already defined warning
+- Don't try to define `WP_REDIS_PLUGIN_PATH` twice
 
 ## 2.4.4
 

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -22,6 +22,7 @@ defined( 'ABSPATH' ) || exit;
 define( 'WP_REDIS_FILE', __FILE__ );
 define( 'WP_REDIS_BASENAME', plugin_basename( WP_REDIS_FILE ) );
 define( 'WP_REDIS_PLUGIN_DIR', plugin_dir_url( WP_REDIS_FILE ) );
+
 if ( ! defined( 'WP_REDIS_PLUGIN_PATH' ) ) {
     define( 'WP_REDIS_PLUGIN_PATH', __DIR__ );
 }

--- a/redis-cache.php
+++ b/redis-cache.php
@@ -20,9 +20,11 @@
 defined( 'ABSPATH' ) || exit;
 
 define( 'WP_REDIS_FILE', __FILE__ );
-define( 'WP_REDIS_PLUGIN_PATH', __DIR__ );
 define( 'WP_REDIS_BASENAME', plugin_basename( WP_REDIS_FILE ) );
 define( 'WP_REDIS_PLUGIN_DIR', plugin_dir_url( WP_REDIS_FILE ) );
+if ( ! defined( 'WP_REDIS_PLUGIN_PATH' ) ) {
+    define( 'WP_REDIS_PLUGIN_PATH', __DIR__ );
+}
 
 $meta = get_file_data( WP_REDIS_FILE, [ 'Version' => 'Version' ] );
 


### PR DESCRIPTION
When using this as a must-use plugin, developers must define `WP_REDIS_PLUGIN_PATH` so the drop-in can locate files. The main plugin file also defines this constant, but without checking if it's already been defined, triggering PHP warnings.

Check if constant is defined before defining it, to avoid warnings.