### PR TITLE
Fix AccelerateWP installation check

### DIFF
--- a/includes/class-plugin.php
+++ b/includes/class-plugin.php
@@ -1611,6 +1611,10 @@ HTML;
             }
         }
 
-        return false;
+        if ( $ignore_banner_constant ) {
+            return false;
+        }
+
+        return defined( 'WP_REDIS_DISABLE_BANNERS' ) && WP_REDIS_DISABLE_BANNERS;
     }
 }


### PR DESCRIPTION
The sidebar in the settings page is now not controlled by `WP_REDIS_DISABLE_BANNERS`, which should be wrong?

https://github.com/rhubarbgroup/redis-cache/blob/1f12771b2a83660da203cf79fe2df9a238f60d89/includes/ui/settings.php#L68-L72