### PR TITLE
Fix issue with loading translated error messages in show_error_and_die

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Actually fix rare fatal error in `show_error_and_die()`
+
 ## 2.5.1
 
 - Added timeouts to diagnostics

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2899,15 +2899,17 @@ LUA;
      * @return void
      */
     protected function show_error_and_die( Exception $exception ) {
-        if ( ! function_exists( 'get_template_directory' ) ) {
-            require_once ABSPATH . WPINC . '/theme.php';
-        }
-
         wp_load_translations_early();
 
-        add_filter( 'pre_determine_locale', function () {
-            return defined( 'WPLANG' ) ? WPLANG : 'en_US';
-        } );
+        $domain = 'redis-cache';
+        $locale = defined( 'WPLANG' ) ? WPLANG : 'en_US';
+        $mofile = WP_LANG_DIR . "/plugins/{$domain}-{$locale}.mo";
+
+        if ( load_textdomain( $domain, $mofile, $locale ) === false ) {
+            add_filter( 'pre_determine_locale', function () {
+                return defined( 'WPLANG' ) ? WPLANG : 'en_US';
+            } );
+        }
 
         // Load custom Redis error template, if present.
         if ( file_exists( WP_CONTENT_DIR . '/redis-error.php' ) ) {


### PR DESCRIPTION
Resolves #507

Try to load plugin textdomain and if failed override locale and options loading to not crash