### PR TITLE
adds support for ssl context in redis clusters

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -683,7 +683,7 @@ class WP_Object_Cache {
                     'cluster' => $this->build_cluster_connection_array(),
                     'timeout' => $parameters['timeout'],
                     'read_timeout' => $parameters['read_timeout'],
-                    'persistent' => $parameters['persistent']
+                    'persistent' => $parameters['persistent'],
                 ];
 
                 if ( isset( $parameters['password'] ) && version_compare( $version, '4.3.0', '>=' ) ) {
@@ -691,7 +691,7 @@ class WP_Object_Cache {
                 }
                 
                 if ( version_compare( $version, '5.3.0', '>=' ) && defined('WP_REDIS_SSL_CONTEXT') && is_array(WP_REDIS_SSL_CONTEXT)) {
-                    isset($args['password']) or $args['password'] = null;
+                    array_key_exists('password', $args) or $args['password'] = null;
                     $args['ssl'] = WP_REDIS_SSL_CONTEXT;
                 }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -691,7 +691,7 @@ class WP_Object_Cache {
                 }
 
                 if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
-                    if ( array_key_exists( 'password', $args ) ) {
+                    if ( ! array_key_exists( 'password', $args ) ) {
                         $args['password'] = null;
                     }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -690,8 +690,11 @@ class WP_Object_Cache {
                     $args['password'] = $parameters['password'];
                 }
                 
-                if ( version_compare( $version, '5.3.0', '>=' ) && defined('WP_REDIS_SSL_CONTEXT') && is_array(WP_REDIS_SSL_CONTEXT)) {
-                    array_key_exists('password', $args) or $args['password'] = null;
+                if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
+                    if ( array_key_exists( 'password', $args ) ) {
+                        $args['password'] = null;
+                    }
+
                     $args['ssl'] = WP_REDIS_SSL_CONTEXT;
                 }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -684,10 +684,16 @@ class WP_Object_Cache {
                     'timeout' => $parameters['timeout'],
                     'read_timeout' => $parameters['read_timeout'],
                     'persistent' => $parameters['persistent'],
+                    'password' => null,
+                    'ssl' => null,
                 ];
 
                 if ( isset( $parameters['password'] ) && version_compare( $version, '4.3.0', '>=' ) ) {
                     $args['password'] = $parameters['password'];
+                }
+                
+                if ( version_compare( $version, '5.3.0', '>=' ) && defined('WP_REDIS_SSL_CONTEXT') && is_array(WP_REDIS_SSL_CONTEXT)) {
+                    $args['ssl'] = WP_REDIS_SSL_CONTEXT;
                 }
 
                 $this->redis = new RedisCluster( null, ...array_values( $args ) );

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -683,9 +683,7 @@ class WP_Object_Cache {
                     'cluster' => $this->build_cluster_connection_array(),
                     'timeout' => $parameters['timeout'],
                     'read_timeout' => $parameters['read_timeout'],
-                    'persistent' => $parameters['persistent'],
-                    'password' => null,
-                    'ssl' => null,
+                    'persistent' => $parameters['persistent']
                 ];
 
                 if ( isset( $parameters['password'] ) && version_compare( $version, '4.3.0', '>=' ) ) {
@@ -693,6 +691,7 @@ class WP_Object_Cache {
                 }
                 
                 if ( version_compare( $version, '5.3.0', '>=' ) && defined('WP_REDIS_SSL_CONTEXT') && is_array(WP_REDIS_SSL_CONTEXT)) {
+                    isset($args['password']) or $args['password'] = null;
                     $args['ssl'] = WP_REDIS_SSL_CONTEXT;
                 }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -689,7 +689,7 @@ class WP_Object_Cache {
                 if ( isset( $parameters['password'] ) && version_compare( $version, '4.3.0', '>=' ) ) {
                     $args['password'] = $parameters['password'];
                 }
-                
+
                 if ( version_compare( $version, '5.3.0', '>=' ) && defined( 'WP_REDIS_SSL_CONTEXT' ) && ! empty( WP_REDIS_SSL_CONTEXT ) ) {
                     if ( array_key_exists( 'password', $args ) ) {
                         $args['password'] = null;


### PR DESCRIPTION
This is necessary when connecting to a REDIS cluster that requires an ssl context (e.g. AWS Elasticache serverless)