### PR TITLE
Fixed  issue with Predis and replication connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `wp_cache_flush_group` issue with Predis and replication connection
+
 ## 2.5.2
 
 - Respect `WP_REDIS_FLUSH_TIMEOUT` in Lua flush scripts


### PR DESCRIPTION
Resolves #519

When using Predis with replication connection we can't get/set flush timeout directly but we need to get master connection and work with it.