### PR TITLE
Fix Redis version determination for predis replication connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fixed `wp_cache_flush_group` issue with Predis and replication connection
+- Fixed Redis version detection issue with Predis and replication connection
 
 ## 2.5.2
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1884,7 +1884,7 @@ class WP_Object_Cache {
                 return i
 LUA;
 
-            if ( version_compare( $this->redis_version(), '5', '<' ) && version_compare( $this->redis_version(), '3.2', '>=' ) ) {
+            if ( isset($this->redis_version) && version_compare( $this->redis_version, '5', '<' ) && version_compare( $this->redis_version, '3.2', '>=' ) ) {
                 $script = 'redis.replicate_commands()' . "\n" . $script;
             }
 
@@ -1936,7 +1936,7 @@ LUA;
                 until 0 == cur
                 return i
 LUA;
-            if ( version_compare( $this->redis_version(), '5', '<' ) && version_compare( $this->redis_version(), '3.2', '>=' ) ) {
+            if ( isset($this->redis_version) && version_compare( $this->redis_version, '5', '<' ) && version_compare( $this->redis_version, '3.2', '>=' ) ) {
                 $script = 'redis.replicate_commands()' . "\n" . $script;
             }
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1147,10 +1147,10 @@ class WP_Object_Cache {
             $info = $this->is_predis()
                 ? $this->redis->getClientBy( 'id', $connectionId )->info()
                 : $this->redis->info( $connectionId );
+        } else if ($this->is_predis() && $this->redis->getConnection() instanceof Predis\Connection\Replication\MasterSlaveReplication) {
+            $info = $this->redis->getClientBy( 'role' , 'master' )->info();
         } else {
-            $info = $this->is_predis() && $this->redis->getConnection() instanceof Predis\Connection\Replication\MasterSlaveReplication
-                ? $this->redis->getClientBy( 'role' , 'master' )->info()
-                : $this->redis->info();
+            $info = $this->redis->info();
         }
 
         if ( isset( $info['redis_version'] ) ) {


### PR DESCRIPTION
The first commit just suppress warning when Redis server version couldn't be determined with `INFO` command.
In the second commit I tried to get `INFO` results from the master node for `MasterSlaveReplication` connection