### PR TITLE
Swith to master before fetching info for predis with replicated connections

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1147,9 +1147,14 @@ class WP_Object_Cache {
             $info = $this->is_predis()
                 ? $this->redis->getClientBy( 'id', $connectionId )->info()
                 : $this->redis->info( $connectionId );
-        } else if ($this->is_predis() && $this->redis->getConnection() instanceof Predis\Connection\Replication\ReplicationInterface) {
-            $info = $this->redis->getMaster()->info();
         } else {
+            if ( $this->is_predis() ) {
+                $connection = $this->redis->getConnection();
+                if ( $connection instanceof Predis\Connection\Replication\ReplicationInterface ) {
+                    $connection->switchToMaster();
+                }
+            }
+
             $info = $this->redis->info();
         }
 


### PR DESCRIPTION
Fixes #543

With this change `wp cache flush` works for me for all configurations from https://github.com/rhubarbgroup/redis-cache?tab=readme-ov-file#scaling
I hope this time it will fix issue for users :crossed_fingers: :smiley: 