### PR TITLE
Switch back to node which were used before fetching info

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1151,11 +1151,16 @@ class WP_Object_Cache {
             if ( $this->is_predis() ) {
                 $connection = $this->redis->getConnection();
                 if ( $connection instanceof Predis\Connection\Replication\ReplicationInterface ) {
+                    $node = $connection->getCurrent();
                     $connection->switchToMaster();
                 }
             }
 
             $info = $this->redis->info();
+
+            if ( isset( $node ) ) {
+                $connection->switchTo($node);
+            }
         }
 
         if ( isset( $info['redis_version'] ) ) {


### PR DESCRIPTION
This fix is related to [543#issuecomment-2558071224](https://github.com/rhubarbgroup/redis-cache/issues/543#issuecomment-2558071224)