### PR TITLE
Fix PhpStan warning

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1158,7 +1158,7 @@ class WP_Object_Cache {
 
             $info = $this->redis->info();
 
-            if ( isset( $connection ) && isset( $node ) ) {
+            if ( isset( $connection, $node ) ) {
                 $connection->switchTo($node);
             }
         }

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1158,7 +1158,7 @@ class WP_Object_Cache {
 
             $info = $this->redis->info();
 
-            if ( isset( $node ) ) {
+            if ( isset( $connection ) && isset( $node ) ) {
                 $connection->switchTo($node);
             }
         }


### PR DESCRIPTION
`$node` can't be set without `$connection` but PhpStan highlights this as error