### PR TITLE
Replace incrBy/decrBy with get+set

### DIFF
--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -2416,9 +2416,13 @@ LUA; // phpcs:enable
         }
 
         try {
-            $result = $this->parse_redis_response( $this->redis->incrBy( $derived_key, $offset ) );
+            $value = (int) $this->parse_redis_response( $this->redis->get( $derived_key ) );
+            $value += $offset;
+            $result = $this->parse_redis_response( $this->redis->set( $derived_key, $this->maybe_serialize( $value ) ) );
 
-            $this->add_to_internal_cache( $derived_key, (int) $this->redis->get( $derived_key ) );
+            if ( $result ) {
+                $this->add_to_internal_cache( $derived_key, $value );
+            }
         } catch ( Exception $exception ) {
             $this->handle_exception( $exception );
 
@@ -2473,9 +2477,13 @@ LUA; // phpcs:enable
         }
 
         try {
-            $result = $this->parse_redis_response( $this->redis->decrBy( $derived_key, $offset ) );
+            $value = (int) $this->parse_redis_response( $this->redis->get( $derived_key ) );
+            $value -= $offset;
+            $result = $this->parse_redis_response( $this->redis->set( $derived_key, $this->maybe_serialize( $value ) ) );
 
-            $this->add_to_internal_cache( $derived_key, (int) $this->redis->get( $derived_key ) );
+            if ( $result ) {
+                $this->add_to_internal_cache( $derived_key, $value );
+            }
         } catch ( Exception $exception ) {
             $this->handle_exception( $exception );
 


### PR DESCRIPTION
Fixes #574 

When serializer enabled Redis can't increment/decrement value because it becomes non-numeric after serializing so in this PR I replaced incrBy/decrBy calls with sequence of get + set commands