### PR TITLE
Discard abandoned pipelines when a bulk command fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `WP_REDIS_CHART_COLOR` constant
 - Added `WP_REDIS_LOAD_APEXCHARTS` constant
 - Upgrade ApexCharts to v4.7.0
+- Fixed bulk cache methods leaving the connection stuck in pipeline mode
 
 ## 2.8.0
 

--- a/includes/object-cache.php
+++ b/includes/object-cache.php
@@ -1250,8 +1250,6 @@ class WP_Object_Cache {
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                $tx->discard();
-
                 return array_fill_keys( $keys, false );
             }
 
@@ -1268,6 +1266,10 @@ class WP_Object_Cache {
             $this->cache_calls++;
             $this->cache_time += $execute_time;
         } catch ( Exception $exception ) {
+            if ( isset( $tx ) ) {
+                $tx->discard();
+            }
+
             $this->handle_exception( $exception );
 
             return array_combine( $keys, array_fill( 0, count( $keys ), false ) );
@@ -1501,13 +1503,15 @@ class WP_Object_Cache {
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                $tx->discard();
-
                 return array_fill_keys( $keys, false );
             }
 
             $execute_time = microtime( true ) - $start_time;
         } catch ( Exception $exception ) {
+            if ( isset( $tx ) ) {
+                $tx->discard();
+            }
+
             $this->handle_exception( $exception );
 
             return array_combine( $keys, array_fill( 0, count( $keys ), false ) );
@@ -2287,8 +2291,6 @@ LUA;
             }, $tx->{$method}() ?: [] );
 
             if ( count( $results ) !== count( $keys ) ) {
-                $tx->discard();
-
                 return array_fill_keys( $keys, false );
             }
 
@@ -2300,6 +2302,10 @@ LUA;
                 }
             }
         } catch ( Exception $exception ) {
+            if ( isset( $tx ) ) {
+                $tx->discard();
+            }
+
             $this->handle_exception( $exception );
 
             return array_combine( $keys, array_fill( 0, count( $keys ), false ) );


### PR DESCRIPTION
Fixes #628.

PhpRedis and Relay put the connection itself into pipeline mode, so a pipeline that is never executed leaves the connection answering every subsequent command with the client object instead of a value. Once that happens:

- `wp_cache_get()` fatals in `add_to_internal_cache()` — *Trying to clone an uncloneable object of class Redis* / *Cannot clone relay object in a pipeline/multi*
- `wp_cache_get_multiple()` fatals in `array_combine()`
- `set()` and `delete()` report `false` while the writes actually reach Redis
- `redis_status()` still reports `true`

The `discard()` calls sat in the `count( $results ) !== count( $keys )` branches, which are only reachable *after* `exec()` has already closed the pipeline, so they never ran when it mattered:

```
exec()                         => [true]
in pipeline mode after exec()? => no      <- already closed
$tx->discard() at that point   => false   <- no-op
```

They were also wrong for two clients where they did run: `Predis\Pipeline\Pipeline` has no `discard()` method, so `__call` queued a literal `DISCARD` command, and Credis raised `ERR DISCARD without MULTI`.

This moves them to the `catch` blocks, where the pipeline is still open.

## Predis

No cleanup is needed — a Predis pipeline is a standalone object rather than a connection mode, so abandoning one leaves the client fully usable. The `catch` still covers it: `PredisException`, `ServerException`, `ConnectionException` and `ClientException` all extend `Exception`, and `discard()` on a Predis pipeline is harmless. Credis never reaches these methods at all, since `method_exists( $client, 'pipeline' )` is `false` for `Credis_Client`.

## Verification

Reproduced and verified against PhpRedis 6.3.0 and Relay 0.40.0 by making `exec()` fail the way a dropped connection or read timeout does. Before the change the connection was left in pipeline mode and every later cache call was wrong; after it, `discard()` runs and the connection stays usable. A functional pass over `add_multiple`/`get`/`set_multiple`/`get_multiple`/`delete_multiple` is green on PhpRedis, Relay, Predis 2.4.1 and Credis.

## Not covered

One path can still abandon a pipeline: in `add_multiple_at_once()` and `set_multiple_at_once()` the queueing loop sits outside the `try`, so an exception raised while queueing — a `redis_cache_expiration` filter, a serialization failure — escapes with the pipeline open. Closing that means moving those loops inside the `try`, which also changes whether such exceptions propagate or get swallowed by `handle_exception()`, so it is left out of this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YSFAznT9RDQ15V6BcVpBEt)_